### PR TITLE
Fix --pg-version check

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -28,8 +28,8 @@ class OSOption:
 
 
 class PgVersionOption:
-    choices = [11, 12, 13]
-    default = 13
+    choices = ['11', '12', '13']
+    default = '13'
     help = textwrap.dedent("""
         PostgreSQL or EPAS version. Allowed values are: 11, 12 and 13.
         Default: %(default)s


### PR DESCRIPTION
The issue was:
error: argument -v/--pg-version: invalid choice: '13' (choose from 11, 12, 13)