### PR TITLE
Pooler security groups

### DIFF
--- a/edbdeploy/data/terraform/aws/environments/security/security.tf
+++ b/edbdeploy/data/terraform/aws/environments/security/security.tf
@@ -56,10 +56,66 @@ resource "aws_security_group" "edb-prereqs-rules" {
     cidr_blocks = [var.public_cidrblock]
   }
 
-  // PgPoolII default port
+  // PgPoolII default port for user connections
+  ingress {
+    from_port   = 9999
+    to_port     = 9999
+    protocol    = "tcp"
+    cidr_blocks = [var.public_cidrblock]
+  }
+
+  // PgPoolII default pcp tcp port
+  ingress {
+    from_port   = 9898
+    to_port     = 9898
+    protocol    = "tcp"
+    cidr_blocks = [var.public_cidrblock]
+  }
+
+  // PgPoolII default watchdog tcp port
   ingress {
     from_port   = 9000
     to_port     = 9000
+    protocol    = "tcp"
+    cidr_blocks = [var.public_cidrblock]
+  }
+
+  // PgPoolII default watchdog tcp heartbeat port
+  ingress {
+    from_port   = 9694
+    to_port     = 9694
+    protocol    = "tcp"
+    cidr_blocks = [var.public_cidrblock]
+  }
+
+  // PgPoolII default pcp udp port
+  ingress {
+    from_port   = 9898
+    to_port     = 9898
+    protocol    = "udp"
+    cidr_blocks = [var.public_cidrblock]
+  }
+
+  // PgPoolII default watchdog udp port
+  ingress {
+    from_port   = 9000
+    to_port     = 9000
+    protocol    = "udp"
+    cidr_blocks = [var.public_cidrblock]
+  }
+
+  // PgPoolII default watchdog heartbeat udp port
+  ingress {
+    from_port   = 9694
+    to_port     = 9694
+    protocol    = "udp"
+    cidr_blocks = [var.public_cidrblock]
+  }
+
+  // PgBouncer default port
+  ingress {
+    from_port   = 6432
+    to_port     = 6432
     protocol    = "tcp"
     cidr_blocks = [var.public_cidrblock]
   }

--- a/edbdeploy/data/terraform/azure/environments/security/security.tf
+++ b/edbdeploy/data/terraform/azure/environments/security/security.tf
@@ -83,12 +83,103 @@ resource "azurerm_network_security_group" "main" {
   // PgPoolII default port
   security_rule {
     name                       = "EDB-PgPoolII"
+    priority                   = 800
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "9999"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  // PgPoolII default pcp port
+  security_rule {
+    name                       = "EDB-PgPoolPCP"
+    priority                   = 801
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "9898"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  // PgPoolII default watchdog port
+  security_rule {
+    name                       = "EDB-PoolWatchDog"
     priority                   = 700
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "9000"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  // PgPoolII default watchdog heart beat port
+  security_rule {
+    name                       = "EDB-PgPoolWDH"
+    priority                   = 802
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "9694"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  // PgPoolII default pcp udp port
+  security_rule {
+    name                       = "EDB-PgPoolPCPUDP"
+    priority                   = 801
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "9898"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  // PgPoolII default watchdog udp port
+  security_rule {
+    name                       = "EDB-PoolWatchDogUDP"
+    priority                   = 700
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "9000"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  // PgPoolII default watchdog heart udp beat port
+  security_rule {
+    name                       = "EDB-PgPoolWDHUDP"
+    priority                   = 802
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "9694"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  // PgBouncer default port
+  security_rule {
+    name                       = "EDB-PgBouncer"
+    priority                   = 900
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "6432"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }

--- a/edbdeploy/data/terraform/gcloud/environments/compute/compute.tf
+++ b/edbdeploy/data/terraform/gcloud/environments/compute/compute.tf
@@ -267,6 +267,7 @@ resource "google_compute_instance" "pem_server" {
 
   tags = [
     format("%s-%s", var.network_name, "firewall-ssh"),
+    format("%s-%s", var.network_name, "firewall-http"),
     format("%s-%s", var.network_name, "firewall-postgresql"),
     format("%s-%s", var.network_name, "firewall-epas"),
     format("%s-%s", var.network_name, "firewall-icmp"),
@@ -313,6 +314,13 @@ resource "google_compute_instance" "pooler_server" {
     format("%s-%s", var.network_name, "firewall-ssh"),
     format("%s-%s", var.network_name, "firewall-icmp"),
     format("%s-%s", var.network_name, "firewall-pgpool"),
+    format("%s-%s", var.network_name, "firewall-pgpool-watchdog"),
+    format("%s-%s", var.network_name, "firewall-pgpool-watchdoghb"),
+    format("%s-%s", var.network_name, "firewall-pgpool-pcp"),
+    format("%s-%s", var.network_name, "firewall-pgpool-watchdogudp"),
+    format("%s-%s", var.network_name, "firewall-pgpool-watchdoghbudp"),
+    format("%s-%s", var.network_name, "firewall-pgpool-pcpudp"),
+    format("%s-%s", var.network_name, "firewall-pgbouncer"),
     format("%s-%s", var.network_name, "firewall-secure-forward"),
   ]
 

--- a/edbdeploy/data/terraform/gcloud/environments/security/firewall.tf
+++ b/edbdeploy/data/terraform/gcloud/environments/security/firewall.tf
@@ -110,10 +110,101 @@ resource "google_compute_firewall" "pgpool" {
 
   allow {
     protocol = "tcp"
-    ports    = ["9000"]
+    ports    = ["9999"]
   }
 
   target_tags = [format("%s-%s", var.network_name, "firewall-pgpool")]
+  source_ranges = [var.source_ranges]
+}
+
+resource "google_compute_firewall" "pgpool-pcp" {
+  name    = format("%s-%s", var.network_name, "firewall-pgpool-pcp")
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9898"]
+  }
+
+  target_tags = [format("%s-%s", var.network_name, "firewall-pgpool-pcp")]
+  source_ranges = [var.source_ranges]
+}
+
+resource "google_compute_firewall" "pgpool-watchdog" {
+  name    = format("%s-%s", var.network_name, "firewall-pgpool-watchdog")
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9000"]
+  }
+
+  target_tags = [format("%s-%s", var.network_name, "firewall-pgpool-watchdog")]
+  source_ranges = [var.source_ranges]
+}
+
+resource "google_compute_firewall" "pgpool-watchdoghb" {
+  name    = format("%s-%s", var.network_name, "firewall-pgpool-watchdoghb")
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9694"]
+  }
+
+  target_tags = [format("%s-%s", var.network_name, "firewall-pgpool-watchdoghb")]
+  source_ranges = [var.source_ranges]
+}
+
+resource "google_compute_firewall" "pgpool-pcpudp" {
+  name    = format("%s-%s", var.network_name, "firewall-pgpool-pcpudp")
+  network = var.network_name
+
+  allow {
+    protocol = "udp"
+    ports    = ["9898"]
+  }
+
+  target_tags = [format("%s-%s", var.network_name, "firewall-pgpool-pcpudp")]
+  source_ranges = [var.source_ranges]
+}
+
+resource "google_compute_firewall" "pgpool-watchdogudp" {
+  name    = format("%s-%s", var.network_name, "firewall-pgpool-watchdogudp")
+  network = var.network_name
+
+  allow {
+    protocol = "udp"
+    ports    = ["9000"]
+  }
+
+  target_tags = [format("%s-%s", var.network_name, "firewall-pgpool-watchdogudp")]
+  source_ranges = [var.source_ranges]
+}
+
+resource "google_compute_firewall" "pgpool-watchdoghbudp" {
+  name    = format("%s-%s", var.network_name, "firewall-pgpool-watchdoghbudp")
+  network = var.network_name
+
+  allow {
+    protocol = "udp"
+    ports    = ["9694"]
+  }
+
+  target_tags = [format("%s-%s", var.network_name, "firewall-pgpool-watchdoghbudp")]
+  source_ranges = [var.source_ranges]
+}
+
+resource "google_compute_firewall" "pgbouncer" {
+  name    = format("%s-%s", var.network_name, "firewall-pgbouncer")
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["6432"]
+  }
+
+  target_tags = [format("%s-%s", var.network_name, "firewall-pgbouncer")]
   source_ranges = [var.source_ranges]
 }
 


### PR DESCRIPTION
Updating pooler security groups. This commit allows the following ports:
1. pgpool watchdog
2. pgpool
3. pgbouncer.
With this fix, also added the HTTP port required for pemserver in GCloud.