### PR TITLE
Pin third party tools version

### DIFF
--- a/scripts/install_requirements_darwin_x64.sh
+++ b/scripts/install_requirements_darwin_x64.sh
@@ -1,9 +1,16 @@
 #!/bin/bash -eu
 
+TERRAFORM_VERSION="0.14.7"
+GCLOUD_SDK_VERSION="329.0.0"
+ANSIBLE_VERSION="2.10.7"
+AWS_CLI_VERSION="1.19.18"
+AZURE_CLI_VERSION="2.20.0"
+
 INSTALL_PATH=${INSTALL_PATH:-$HOME/.edb-cloud-tools}
 
-TERRAFORM_ARCHIVE=https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_darwin_amd64.zip
-GCLOUD_ARCHIVE=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-324.0.0-darwin-x86_64.tar.gz
+TERRAFORM_ARCHIVE=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_darwin_amd64.zip
+
+GCLOUD_ARCHIVE=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_SDK_VERSION}-darwin-x86_64.tar.gz
 
 mkdir -p ${INSTALL_PATH}
 mkdir -p ${INSTALL_PATH}/bin
@@ -14,7 +21,7 @@ mkdir -p ${INSTALL_PATH}/aws
 python3 -m venv ${INSTALL_PATH}/aws
 sed -i.bak 's/$1/${1:-}/' ${INSTALL_PATH}/aws/bin/activate
 source ${INSTALL_PATH}/aws/bin/activate
-pip3 install awscli
+python3 -m pip install "awscli==${AWS_CLI_VERSION}"
 deactivate
 ln -sf ${INSTALL_PATH}/aws/bin/aws ${INSTALL_PATH}/bin/.
 
@@ -23,7 +30,12 @@ mkdir -p ${INSTALL_PATH}/azure
 python3 -m venv ${INSTALL_PATH}/azure
 sed -i.bak 's/$1/${1:-}/' ${INSTALL_PATH}/azure/bin/activate
 source ${INSTALL_PATH}/azure/bin/activate
-pip3 install azure-cli
+# cryptography should be pinned to 3.3.2 because the next
+# version introduces rust as a dependency for building it and
+# breaks compatiblity with some pip versions.
+# ref: https://github.com/Azure/azure-cli/issues/16858
+python3 -m pip install "cryptography==3.3.2"
+python3 -m pip install "azure-cli==${AZURE_CLI_VERSION}"
 deactivate
 ln -sf ${INSTALL_PATH}/azure/bin/az ${INSTALL_PATH}/bin/.
 
@@ -38,7 +50,8 @@ mkdir -p ${INSTALL_PATH}/ansible
 python3 -m venv ${INSTALL_PATH}/ansible
 sed -i.bak 's/$1/${1:-}/' ${INSTALL_PATH}/ansible/bin/activate
 source ${INSTALL_PATH}/ansible/bin/activate
-pip3 install ansible
+python3 -m pip install "cryptography==3.3.2"
+python3 -m pip install "ansible==${ANSIBLE_VERSION}"
 deactivate
 ln -sf ${INSTALL_PATH}/ansible/bin/ansible ${INSTALL_PATH}/bin/.
 ln -sf ${INSTALL_PATH}/ansible/bin/ansible-galaxy ${INSTALL_PATH}/bin/.

--- a/scripts/install_requirements_linux_x64.sh
+++ b/scripts/install_requirements_linux_x64.sh
@@ -1,9 +1,15 @@
 #!/bin/bash -eu
 
+TERRAFORM_VERSION="0.14.7"
+GCLOUD_SDK_VERSION="329.0.0"
+ANSIBLE_VERSION="2.10.7"
+AWS_CLI_VERSION="1.19.18"
+AZURE_CLI_VERSION="2.20.0"
+
 INSTALL_PATH=${INSTALL_PATH:-$HOME/.edb-cloud-tools}
 
-TERRAFORM_ARCHIVE=https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_linux_amd64.zip
-GCLOUD_ARCHIVE=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-324.0.0-linux-x86_64.tar.gz
+TERRAFORM_ARCHIVE=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+GCLOUD_ARCHIVE=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_SDK_VERSION}-linux-x86_64.tar.gz
 
 mkdir -p ${INSTALL_PATH}
 mkdir -p ${INSTALL_PATH}/bin
@@ -14,7 +20,7 @@ mkdir -p ${INSTALL_PATH}/aws
 python3 -m venv ${INSTALL_PATH}/aws
 sed -i.bak 's/$1/${1:-}/' ${INSTALL_PATH}/aws/bin/activate
 source ${INSTALL_PATH}/aws/bin/activate
-pip3 install awscli
+python3 -m pip install "awscli==${AWS_CLI_VERSION}"
 deactivate
 ln -sf ${INSTALL_PATH}/aws/bin/aws ${INSTALL_PATH}/bin/.
 
@@ -23,7 +29,12 @@ mkdir -p ${INSTALL_PATH}/azure
 python3 -m venv ${INSTALL_PATH}/azure
 sed -i.bak 's/$1/${1:-}/' ${INSTALL_PATH}/azure/bin/activate
 source ${INSTALL_PATH}/azure/bin/activate
-pip3 install azure-cli
+# cryptography should be pinned to 3.3.2 because the next
+# version introduces rust as a dependency for building it and
+# breaks compatiblity with some pip versions.
+# ref: https://github.com/Azure/azure-cli/issues/16858
+python3 -m pip install "cryptography==3.3.2"
+python3 -m pip install "azure-cli==${AZURE_CLI_VERSION}"
 deactivate
 ln -sf ${INSTALL_PATH}/azure/bin/az ${INSTALL_PATH}/bin/.
 
@@ -38,7 +49,8 @@ mkdir -p ${INSTALL_PATH}/ansible
 python3 -m venv ${INSTALL_PATH}/ansible
 sed -i.bak 's/$1/${1:-}/' ${INSTALL_PATH}/ansible/bin/activate
 source ${INSTALL_PATH}/ansible/bin/activate
-pip3 install ansible
+python3 -m pip install "cryptography==3.3.2"
+python3 -m pip install "ansible==${ANSIBLE_VERSION}"
 deactivate
 ln -sf ${INSTALL_PATH}/ansible/bin/ansible ${INSTALL_PATH}/bin/.
 ln -sf ${INSTALL_PATH}/ansible/bin/ansible-galaxy ${INSTALL_PATH}/bin/.


### PR DESCRIPTION
At the moment, edb-ansible is not yet ready for Ansible 3, so, we
ensure the installation of the last 2.10.

Azure CLI and Ansible depend on the cryptography module, but the
last version of this python module requires rust for building it.
This is not supported by old pip version, then we pin cyptography
version to 3.3.2, which does not require rust.