### PR TITLE
Update regex for checking azure-cli version

### DIFF
--- a/edbdeploy/cloud.py
+++ b/edbdeploy/cloud.py
@@ -247,7 +247,7 @@ class AzureCli:
 
         version = None
         # Parse command output and extract the version number
-        pattern = re.compile(r"^azure-cli\s+([0-9]+)\.([0-9]+)\.([0-9]+)$")
+        pattern = re.compile(r"^azure-cli\s+([0-9]+)\.([0-9]+)\.([0-9]+)")
         for line in output.decode("utf-8").split("\n"):
             m = pattern.search(line)
             if m:


### PR DESCRIPTION
Remove the expectation that the end of the line is immediately after
the version number.  Something it may look like this:

azure-cli                         2.20.0 *