### PR TITLE
Baremetal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 `edb-deployment` tool is an easy way to provision Cloud resources and deploy
 PostgreSQL, EDB Postgres Advanced Server and tools (high availability,
-backup/recovery, monitoring, connection poolers).
+backup/recovery, monitoring, connection poolers). `edb-deployment` can also be
+used to deploy Postgres architectures on existing infrastructure like physical
+servers (baremetal) or local Virtual Machines.
 
 Supported Cloud providers are **AWS**, **Azure** and **Google Cloud**.
 
@@ -231,6 +233,37 @@ To change these configuration values, you need first to dump the default values
 with:
 ```shell
 $ edb-deployment <CLOUD_VENDOR> specs > my_configuration.json
+```
+
+When deploying on baremetal servers, IP address and SSH user configuration must
+be done through the specifications:
+
+```shell
+$ edb-deployment baremetal specs --reference-architecture EDB-RA-1 > baremetal-edb-ra-1.json
+```
+
+The `baremetal-edb-ra-1.json` file will contain:
+```json
+{
+  "ssh_user": null,
+  "pg_data": null,
+  "pg_wal": null,
+  "postgres_server_1": {
+    "name": "pg1",
+    "public_ip": null,
+    "private_ip": null
+  },
+  "pem_server_1": {
+    "name": "pem1",
+    "public_ip": null,
+    "private_ip": null
+  },
+  "backup_server_1": {
+    "name": "backup1",
+    "public_ip": null,
+    "private_ip": null
+  }
+}
 ```
 
 Then, you can edit and update resources configuration stored in the JSON file.

--- a/edbdeploy/cli.py
+++ b/edbdeploy/cli.py
@@ -7,6 +7,7 @@ from .commands import (
     aurora as aws_rds_aurora,
     aws,
     azure,
+    baremetal,
     rds as aws_rds,
     gcloud,
 )
@@ -42,6 +43,9 @@ def parse():
     )
     azure_parser = subparsers.add_parser('azure', help='Azure Cloud')
     gcloud_parser = subparsers.add_parser('gcloud', help='Google Cloud')
+    baremetal_parser = subparsers.add_parser(
+        'baremetal', help='Baremetal servers and VMs'
+    )
 
     # Sub-commands parsers
     aws_subparser = aws_parser.add_subparsers(
@@ -61,6 +65,10 @@ def parse():
         title='GCloud sub-commands', dest='sub_command',
         metavar='<sub-command>'
     )
+    baremetal_subparser = baremetal_parser.add_subparsers(
+        title='Baremetal sub-commands', dest='sub_command',
+        metavar='<sub-command>'
+    )
 
     # Attach sub-commands options to the sub-parsers
     aws.subcommands(aws_subparser)
@@ -68,6 +76,7 @@ def parse():
     aws_rds_aurora.subcommands(aws_rds_aurora_subparser)
     azure.subcommands(azure_subparser)
     gcloud.subcommands(gcloud_subparser)
+    baremetal.subcommands(baremetal_subparser)
 
     # Autocompletion with argcomplete
     argcomplete.autocomplete(parser)
@@ -98,6 +107,8 @@ def parse():
             azure_parser.print_help()
         elif env.cloud == 'gcloud':
             gcloud_parser.print_help()
+        elif env.cloud == 'baremetal':
+            baremetal_parser.print_help()
         sys.stderr.write('error: too few arguments\n')
         sys.exit(2)
 

--- a/edbdeploy/command.py
+++ b/edbdeploy/command.py
@@ -108,4 +108,7 @@ class Commander:
 
     def specs(self):
         logging.info("Showing default specs. for cloud %s", self.env.cloud)
-        Project.show_specs(self.env.cloud)
+        Project.show_specs(
+            self.env.cloud,
+            getattr(self.env, 'reference_architecture', None)
+        )

--- a/edbdeploy/commands/aws.py
+++ b/edbdeploy/commands/aws.py
@@ -20,10 +20,10 @@ def subcommands(subparser):
     subcommand_parsers['configure'].add_argument(
         '-a', '--reference-architecture',
         dest='reference_architecture',
-        choices=ReferenceArchitectureOption.choices,
-        default=ReferenceArchitectureOption.default,
+        choices=ReferenceArchitectureOptionAWS.choices,
+        default=ReferenceArchitectureOptionAWS.default,
         metavar='<ref-arch-code>',
-        help=ReferenceArchitectureOption.help
+        help=ReferenceArchitectureOptionAWS.help
     )
     subcommand_parsers['configure'].add_argument(
         '-u', '--edb-credentials',

--- a/edbdeploy/commands/baremetal.py
+++ b/edbdeploy/commands/baremetal.py
@@ -1,0 +1,126 @@
+import argparse
+
+from ..options import *
+from .default import default_subcommand_parsers
+
+# Baremetal sub-commands and options
+def subcommands(subparser):
+    # List of the sub-commands we want to be available for the baremetal
+    # command
+    available_subcommands = [
+        'configure', 'deploy', 'display', 'list', 'logs', 'passwords', 'show',
+        'specs', 'remove'
+    ]
+
+    # Get sub-commands parsers
+    subcommand_parsers = default_subcommand_parsers(
+        subparser, available_subcommands
+    )
+
+    # baremetal configure sub-command options
+    subcommand_parsers['configure'].add_argument(
+        '-a', '--reference-architecture',
+        dest='reference_architecture',
+        choices=ReferenceArchitectureOption.choices,
+        default=ReferenceArchitectureOption.default,
+        metavar='<ref-arch-code>',
+        help=ReferenceArchitectureOption.help
+    )
+    subcommand_parsers['configure'].add_argument(
+        '-u', '--edb-credentials',
+        dest='edb_credentials',
+        required=True,
+        type=EDBCredentialsType,
+        metavar='"<username>:<password>"',
+        help="EDB Packages repository credentials."
+    ).completer = edb_credentials_completer
+    subcommand_parsers['configure'].add_argument(
+        '-t', '--pg-type',
+        dest='postgres_type',
+        choices=PgTypeOption.choices,
+        default=PgTypeOption.default,
+        metavar='<postgres-engine-type>',
+        help=PgTypeOption.help
+    )
+    subcommand_parsers['configure'].add_argument(
+        '-v', '--pg-version',
+        dest='postgres_version',
+        choices=PgVersionOption.choices,
+        default=PgVersionOption.default,
+        metavar='<postgres-version>',
+        help=PgVersionOption.help
+    )
+    subcommand_parsers['configure'].add_argument(
+        '-e', '--efm-version',
+        dest='efm_version',
+        choices=EFMVersionOption.choices,
+        default=EFMVersionOption.default,
+        metavar='<efm-version>',
+        help=EFMVersionOption.help
+    )
+    subcommand_parsers['configure'].add_argument(
+        '-k', '--ssh-pub-key',
+        dest='ssh_pub_key',
+        type=argparse.FileType('r'),
+        default=SSHPubKeyOption.default(),
+        metavar='<ssh-public-key-file>',
+        help=SSHPubKeyOption.help
+    )
+    subcommand_parsers['configure'].add_argument(
+        '-K', '--ssh-private-key',
+        dest='ssh_priv_key',
+        type=argparse.FileType('r'),
+        default=SSHPrivKeyOption.default(),
+        metavar='<ssh-private-key-file>',
+        help=SSHPrivKeyOption.help
+    )
+    subcommand_parsers['configure'].add_argument(
+        '-s', '--spec',
+        dest='spec_file',
+        type=argparse.FileType('r'),
+        metavar='<baremetal-spec-file>',
+        help="Baremetal servers specification file, in JSON."
+    )
+    # baremetal logs sub-command options
+    subcommand_parsers['logs'].add_argument(
+        '-t', '--tail',
+        dest='tail',
+        action='store_true',
+        help="Do not stop at the end of file."
+    )
+    # baremetal deploy sub-command options
+    subcommand_parsers['deploy'].add_argument(
+        '-n', '--no-install-collection',
+        dest='no_install_collection',
+        action='store_true',
+        help="Do not install the Ansible collection."
+    )
+    subcommand_parsers['deploy'].add_argument(
+        '-p', '--pre-deploy-ansible',
+        dest='pre_deploy_ansible',
+        type=argparse.FileType('r'),
+        metavar='<pre-deploy-ansible-playbook>',
+        help="Pre deploy ansible playbook."
+    )
+    subcommand_parsers['deploy'].add_argument(
+        '-P', '--post-deploy-ansible',
+        dest='post_deploy_ansible',
+        type=argparse.FileType('r'),
+        metavar='<post-deploy-ansible-playbook>',
+        help="Post deploy ansible playbook."
+    )
+    subcommand_parsers['deploy'].add_argument(
+        '-S', '--skip-main-playbook',
+        dest='skip_main_playbook',
+        action='store_true',
+        help="Skip main playbook of the reference architecture."
+    )
+    # baremetal specs sub-command options
+    subcommand_parsers['specs'].add_argument(
+        '-a', '--reference-architecture',
+        dest='reference_architecture',
+        choices=ReferenceArchitectureOption.choices,
+        default=ReferenceArchitectureOption.default,
+        metavar='<ref-arch-code>',
+        help=ReferenceArchitectureOption.help
+    )

--- a/edbdeploy/options.py
+++ b/edbdeploy/options.py
@@ -3,9 +3,24 @@ import re
 import textwrap
 from .project import Project
 
+
 class ReferenceArchitectureOption:
-    choices = ['EDB-RA-1', 'EDB-RA-2', 'EDB-RA-3', 'HammerDB-DBaaS',
-               'HammerDB-TPROC-C']
+    choices = ['EDB-RA-1', 'EDB-RA-2', 'EDB-RA-3']
+
+    default = 'EDB-RA-1'
+    help = textwrap.dedent("""
+        Reference architecture code name. Allowed values are: EDB-RA-1 for a
+        single Postgres node deployment with one backup server and one PEM
+        monitoring server, EDB-RA-2 for a 3 Postgres nodes deployment with
+        quorum base synchronous replication and automatic failover, one backup
+        server and one PEM monitoring server, EDB-RA-3 for extending EDB-RA-2
+        with 3 PgPoolII nodes. Default:
+        %(default)s
+    """)
+
+
+class ReferenceArchitectureOptionAWS:
+    choices = ['EDB-RA-1', 'EDB-RA-2', 'EDB-RA-3', 'HammerDB-TPROC-C']
 
     default = 'EDB-RA-1'
     help = textwrap.dedent("""

--- a/edbdeploy/project.py
+++ b/edbdeploy/project.py
@@ -192,9 +192,15 @@ class Project:
         with AM("Loading Cloud specifications"):
             if getattr(env, 'spec_file', False):
                 user_spec = self._load_spec_file(env.spec_file.name)
-                cloud_spec = merge_user_spec(env.cloud, user_spec)
+                cloud_spec = merge_user_spec(
+                    env.cloud,
+                    user_spec,
+                    getattr(env, 'reference_architecture', None)
+                )
             else:
-                cloud_spec = default_spec(env.cloud)
+                cloud_spec = default_spec(
+                    env.cloud, getattr(env, 'reference_architecture', None)
+                )
 
         logging.debug("cloud_specs=%s", cloud_spec)
         return cloud_spec
@@ -736,7 +742,6 @@ class Project:
             'ssh_user': os['ssh_user'],
         }
 
-
     def _awsrdsaurora_build_terraform_vars(self, env):
         """
         Build Terraform variable for AWS RDS Aurora provisioning
@@ -1195,6 +1200,8 @@ class Project:
         sys.stdout.flush()
 
     @staticmethod
-    def show_specs(cloud):
-        sys.stdout.write(json.dumps(default_spec(cloud), indent=2))
+    def show_specs(cloud, reference_architecture=None):
+        sys.stdout.write(
+            json.dumps(default_spec(cloud, reference_architecture), indent=2)
+        )
         sys.stdout.flush()

--- a/edbdeploy/spec/baremetal.py
+++ b/edbdeploy/spec/baremetal.py
@@ -2,6 +2,9 @@ from . import SpecValidator
 
 BaremetalSpec = {
     'EDB-RA-1': {
+        'ssh_user': SpecValidator(type='string', default=None),
+        'pg_data': SpecValidator(type='string', default=None),
+        'pg_wal': SpecValidator(type='string', default=None),
         'postgres_server_1': {
             'name': SpecValidator(type='string', default='pg1'),
             'public_ip': SpecValidator(type='ipv4', default=None),
@@ -19,6 +22,9 @@ BaremetalSpec = {
         }
     },
     'EDB-RA-2': {
+        'ssh_user': SpecValidator(type='string', default=None),
+        'pg_data': SpecValidator(type='string', default=None),
+        'pg_wal': SpecValidator(type='string', default=None),
         'postgres_server_1': {
             'name': SpecValidator(type='string', default='pg1'),
             'public_ip': SpecValidator(type='ipv4', default=None),
@@ -46,6 +52,9 @@ BaremetalSpec = {
         }
     },
     'EDB-RA-3': {
+        'ssh_user': SpecValidator(type='string', default=None),
+        'pg_data': SpecValidator(type='string', default=None),
+        'pg_wal': SpecValidator(type='string', default=None),
         'postgres_server_1': {
             'name': SpecValidator(type='string', default='pg1'),
             'public_ip': SpecValidator(type='ipv4', default=None),

--- a/edbdeploy/spec/baremetal.py
+++ b/edbdeploy/spec/baremetal.py
@@ -1,0 +1,90 @@
+from . import SpecValidator
+
+BaremetalSpec = {
+    'EDB-RA-1': {
+        'postgres_server_1': {
+            'name': SpecValidator(type='string', default='pg1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'pem_server_1': {
+            'name': SpecValidator(type='string', default='pem1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'backup_server_1': {
+            'name': SpecValidator(type='string', default='backup1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        }
+    },
+    'EDB-RA-2': {
+        'postgres_server_1': {
+            'name': SpecValidator(type='string', default='pg1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'postgres_server_2': {
+            'name': SpecValidator(type='string', default='pg2'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'postgres_server_3': {
+            'name': SpecValidator(type='string', default='pg3'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'pem_server_1': {
+            'name': SpecValidator(type='string', default='pem1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'backup_server_1': {
+            'name': SpecValidator(type='string', default='backup1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        }
+    },
+    'EDB-RA-3': {
+        'postgres_server_1': {
+            'name': SpecValidator(type='string', default='pg1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'postgres_server_2': {
+            'name': SpecValidator(type='string', default='pg2'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'postgres_server_3': {
+            'name': SpecValidator(type='string', default='pg3'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'pooler_server_1': {
+            'name': SpecValidator(type='string', default='pooler1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'pooler_server_2': {
+            'name': SpecValidator(type='string', default='pooler2'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'pooler_server_3': {
+            'name': SpecValidator(type='string', default='pooler3'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'pem_server_1': {
+            'name': SpecValidator(type='string', default='pem1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        },
+        'backup_server_1': {
+            'name': SpecValidator(type='string', default='backup1'),
+            'public_ip': SpecValidator(type='ipv4', default=None),
+            'private_ip': SpecValidator(type='ipv4', default=None),
+        }
+    }
+}

--- a/edbdeploy/specifications.py
+++ b/edbdeploy/specifications.py
@@ -1,9 +1,12 @@
+import socket
+
 from .spec import SpecValidator
 from .spec.aws import AWSSpec
 from .spec.aws_rds import AWSRDSSpec
 from .spec.aws_rds_aurora import AWSRDSAuroraSpec
 from .spec.azure import AzureSpec
 from .spec.gcloud import GCloudSpec
+from .spec.baremetal import BaremetalSpec
 
 class SpecValidatorError(Exception):
     pass
@@ -58,6 +61,14 @@ def validate(value, validator, path):
                 % ('.'.join(path), value, validator.min, validator.max)
             )
 
+    elif validator.type == 'ipv4':
+        try:
+            socket.inet_aton(value)
+        except socket.error:
+            raise SpecValidatorError(
+                "%s: invalid IPv4 address format %s" % ('.'.join(path), value)
+            )
+
     elif validator.type == 'string':
         value = str(value)
 
@@ -82,7 +93,7 @@ def default(element):
 
     return result
 
-def default_spec(cloud):
+def default_spec(cloud, reference_architecture=None):
     """
     Wrapper for the default function
     """
@@ -96,10 +107,12 @@ def default_spec(cloud):
         return default(AzureSpec)
     elif cloud == 'gcloud':
         return default(GCloudSpec)
+    elif cloud == 'baremetal':
+        return default(BaremetalSpec.get(reference_architecture))
     else:
         return {}
 
-def merge_user_spec(cloud, user_spec):
+def merge_user_spec(cloud, user_spec, reference_architecture=None):
     """
     Wrapper function for merging user specs. and default specs.
     """
@@ -113,6 +126,8 @@ def merge_user_spec(cloud, user_spec):
         cloud_spec = AzureSpec
     elif cloud == 'gcloud':
         cloud_spec = GCloudSpec
+    elif cloud == 'baremetal':
+        cloud_spec = BaremetalSpec.get(reference_architecture)
 
     defaults = default(cloud_spec)
 

--- a/edbdeploy/specifications.py
+++ b/edbdeploy/specifications.py
@@ -70,7 +70,7 @@ def validate(value, validator, path):
             )
 
     elif validator.type == 'string':
-        value = str(value)
+        value = str(value) if value is not None else None
 
     return value
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ Advanced Server, and EDB Tools in the Cloud.
     ],
     keywords="postgresql edb epas cli deploy cloud aws rds aurora azure gcloud",
     python_requires=">=2.7",
-    install_requires=["argcomplete"],
+    install_requires=["argcomplete", "PyYAML"],
     extras_require={},
     data_files=[
         (


### PR DESCRIPTION
This PR allows to deploy the reference architectures on already provisioned infrastructure, ie: baremetal servers, local VMs, etc..

The new cloud vendor `baremetal` is added:
```shell
$ edb-deployment baremetal <sub-command> [options] <project-name>
```

IP address configuration must be done with the help of the specifications mechanism:

1.  Dump default specs for the target ref. architecture:
```shell
$ edb-deployment baremetal specs --reference-architecture EDB-RA-1 > ~/bare1.json
```
2. Configure IP addresses in `~/bare1.json`:
```json
{
  "ssh_user": null,
  "pg_data": null,
  "pg_wal": null,
  "postgres_server_1": {
    "name": "pg1",
    "public_ip": "192.168.122.23",
    "private_ip": "192.168.122.23"
  },
  "pem_server_1": {
    "name": "pem1",
    "public_ip": "192.168.122.24",
    "private_ip": "192.168.122.24"
  },
  "backup_server_1": {
    "name": "backup1",
    "public_ip": "192.168.122.25",
    "private_ip": "192.168.122.25"
  }
}
```
3. Configure new project:
```shell
$ edb-deployment baremetal configure [options] --reference-architecture EDB-RA-1 --spec ~/bare1.json
```
4. Deploy the reference architecture:
```shell
$ edb-deployment baremetal deploy <project-name>
```