### PR TITLE
Remove unintentional change to gcloud provisioning

### DIFF
--- a/edbdeploy/project.py
+++ b/edbdeploy/project.py
@@ -1134,8 +1134,7 @@ class Project:
                     (self.terraform_vars['postgres_server']['count']
                      + self.terraform_vars['barman_server']['count']
                      + self.terraform_vars['pem_server']['count']
-                     + self.terraform_vars['pooler_server']['count']
-                     + self.terraform_vars['hammerdb_server']['count'])
+                     + self.terraform_vars['pooler_server']['count'])
                 )
 
 


### PR DESCRIPTION
The setting of the terraform variable for hammerdb_server is meant for
another set of patches.