### PR TITLE
Add hammerdb architecture to gcloud

### DIFF
--- a/edbdeploy/commands/aws.py
+++ b/edbdeploy/commands/aws.py
@@ -20,10 +20,10 @@ def subcommands(subparser):
     subcommand_parsers['configure'].add_argument(
         '-a', '--reference-architecture',
         dest='reference_architecture',
-        choices=ReferenceArchitectureOptionAWS.choices,
-        default=ReferenceArchitectureOptionAWS.default,
+        choices=ReferenceArchitectureOption.choices,
+        default=ReferenceArchitectureOption.default,
         metavar='<ref-arch-code>',
-        help=ReferenceArchitectureOptionAWS.help
+        help=ReferenceArchitectureOption.help
     )
     subcommand_parsers['configure'].add_argument(
         '-u', '--edb-credentials',

--- a/edbdeploy/data/terraform/gcloud/environments/compute/compute.tf
+++ b/edbdeploy/data/terraform/gcloud/environments/compute/compute.tf
@@ -16,6 +16,8 @@ variable "ssh_priv_key" {}
 variable "ssh_pub_key" {}
 variable "ssh_user" {}
 variable "subnetwork_name" {}
+variable "hammerdb_server" {}
+variable "hammerdb" {}
 
 locals {
   lnx_device_names = [
@@ -337,6 +339,47 @@ resource "google_compute_instance" "pooler_server" {
 
     access_config {
       nat_ip = element(google_compute_address.pooler_public_ip.*.address, count.index)
+    }
+
+  }
+
+  metadata = {
+    ssh-keys = format("%s:%s", var.ssh_user, file(var.ssh_pub_key))
+  }
+}
+
+resource "google_compute_address" "hammerdb_public_ip" {
+  count  = var.hammerdb_server["count"]
+  name   = format("hammerdb-public-ip-%s", count.index + 1)
+  region = var.gcloud_region
+}
+
+resource "google_compute_instance" "hammerdb_server" {
+  count        = var.hammerdb_server["count"]
+  name         = (count.index == 0 ? format("%s-%s", var.cluster_name, "hammerdb") : format("%s-%s%s", var.cluster_name, "standby", count.index))
+  machine_type = var.hammerdb_server["instance_type"]
+
+  zone = element(data.google_compute_zones.available.names, count.index)
+
+  tags = [
+    format("%s-%s", var.network_name, "firewall-ssh"),
+    format("%s-%s", var.network_name, "firewall-icmp"),
+    format("%s-%s", var.network_name, "firewall-secure-forward"),
+  ]
+
+  boot_disk {
+    initialize_params {
+      image = var.gcloud_image
+      type  = var.hammerdb_server["volume"]["type"]
+      size  = var.hammerdb_server["volume"]["size"]
+    }
+  }
+
+  network_interface {
+    subnetwork = var.network_name
+
+    access_config {
+      nat_ip = element(google_compute_address.hammerdb_public_ip.*.address, count.index)
     }
 
   }

--- a/edbdeploy/data/terraform/gcloud/environments/compute/outputs.tf
+++ b/edbdeploy/data/terraform/gcloud/environments/compute/outputs.tf
@@ -18,6 +18,15 @@ all:
           ansible_host: ${google_compute_instance.barman_server[0].network_interface.0.access_config.0.nat_ip}
           private_ip: ${google_compute_instance.barman_server[0].network_interface.0.network_ip}
 %{endif ~}
+%{for hammerdb_count in range(var.hammerdb_server["count"]) ~}
+%{if hammerdb_count == 0 ~}
+    hammerdbserver:
+      hosts:
+        hammerdbserver1:
+          ansible_host: ${google_compute_instance.hammerdb_server[hammerdb_count].network_interface.0.access_config.0.nat_ip}
+          private_ip: ${google_compute_instance.hammerdb_server[hammerdb_count].network_interface.0.network_ip}
+%{endif ~}
+%{endfor ~}
 %{for postgres_count in range(var.postgres_server["count"]) ~}
 %{if postgres_count == 0 ~}
     primary:
@@ -38,6 +47,12 @@ all:
           barman_server_private_ip: ${google_compute_instance.barman_server[0].network_interface.0.network_ip}
           barman_backup_method: postgres
 %{endif ~}
+%{for hammerdb_count in range(var.hammerdb_server["count"]) ~}
+%{if var.hammerdb == true ~}
+          hammerdb: true
+          hammerdb_server_private_ip: ${google_compute_instance.hammerdb_server[hammerdb_count].network_interface.0.network_ip}
+%{endif ~}
+%{endfor ~}
 %{if var.pooler_local == true && var.pooler_type == "pgbouncer" ~}
           pgbouncer: true
 %{endif ~}

--- a/edbdeploy/data/terraform/gcloud/main.tf
+++ b/edbdeploy/data/terraform/gcloud/main.tf
@@ -23,6 +23,7 @@ module "compute" {
   pem_server                          = var.pem_server
   barman_server                       = var.barman_server
   pooler_server                       = var.pooler_server
+  hammerdb_server                     = var.hammerdb_server
   pooler_type                         = var.pooler_type
   pooler_local                        = var.pooler_local
   barman                              = var.barman
@@ -37,6 +38,7 @@ module "compute" {
   ssh_priv_key                        = var.ssh_priv_key
   ansible_inventory_yaml_filename     = var.ansible_inventory_yaml_filename
   add_hosts_filename                  = var.add_hosts_filename
+  hammerdb                            = var.hammerdb
 
   depends_on = [module.security]
 }

--- a/edbdeploy/data/terraform/gcloud/variables.tf.template
+++ b/edbdeploy/data/terraform/gcloud/variables.tf.template
@@ -15,6 +15,8 @@ variable "replication_type" {}
 variable "ssh_priv_key" {}
 variable "ssh_pub_key" {}
 variable "ssh_user" {}
+variable "hammerdb_server" {}
+variable "hammerdb" {}
 
 variable "ip_cidr_range" {
   default = "10.0.0.0/16"

--- a/edbdeploy/options.py
+++ b/edbdeploy/options.py
@@ -5,21 +5,6 @@ from .project import Project
 
 
 class ReferenceArchitectureOption:
-    choices = ['EDB-RA-1', 'EDB-RA-2', 'EDB-RA-3']
-
-    default = 'EDB-RA-1'
-    help = textwrap.dedent("""
-        Reference architecture code name. Allowed values are: EDB-RA-1 for a
-        single Postgres node deployment with one backup server and one PEM
-        monitoring server, EDB-RA-2 for a 3 Postgres nodes deployment with
-        quorum base synchronous replication and automatic failover, one backup
-        server and one PEM monitoring server, EDB-RA-3 for extending EDB-RA-2
-        with 3 PgPoolII nodes. Default:
-        %(default)s
-    """)
-
-
-class ReferenceArchitectureOptionAWS:
     choices = ['EDB-RA-1', 'EDB-RA-2', 'EDB-RA-3', 'HammerDB-TPROC-C']
 
     default = 'EDB-RA-1'
@@ -46,7 +31,7 @@ class ReferenceArchitectureOptionRDS:
     """)
 
 
-class ReferenceArchitectureOptionAzure(ReferenceArchitectureOptionAWS):
+class ReferenceArchitectureOptionAzure(ReferenceArchitectureOption):
     pass
 
 

--- a/edbdeploy/project.py
+++ b/edbdeploy/project.py
@@ -725,6 +725,7 @@ class Project:
         pem = env.cloud_spec['pem_server']
         barman = env.cloud_spec['barman_server']
         pooler = env.cloud_spec['pooler_server']
+        hammerdb = env.cloud_spec['hammerdb_server']
 
         self.terraform_vars = {
             'barman': ra['barman'],
@@ -739,6 +740,12 @@ class Project:
             'gcloud_region': env.gcloud_region,
             'gcloud_credentials': env.gcloud_credentials.name,
             'gcloud_project_id': env.gcloud_project_id,
+            'hammerdb': ra['hammerdb'],
+            'hammerdb_server': {
+                'count': 1 if ra['hammerdb_server'] else 0,
+                'instance_type': hammerdb['instance_type'],
+                'volume': hammerdb['volume'],
+            },
             'pem_server': {
                 'count': 1 if ra['pem_server'] else 0,
                 'instance_type': pem['instance_type'],

--- a/edbdeploy/spec/gcloud.py
+++ b/edbdeploy/spec/gcloud.py
@@ -19,13 +19,56 @@ GCloudSpec = {
             'ssh_user': SpecValidator(type='string', default='edbadm')
         }
     },
+    'hammerdb_server': {
+        'instance_type': SpecValidator(
+            type='choice',
+            choices=[
+                'c2-standard-4', 'c2-standard-8', 'c2-standard-16'
+            ],
+            default='c2-standard-4'
+        ),
+        'volume': {
+            'type': SpecValidator(
+                type='choice',
+                choices=['pd-standard', 'pd-ssd'],
+                default='pd-standard'
+            ),
+            'size': SpecValidator(
+                type='integer',
+                min=10,
+                max=16000,
+                default=50
+            )
+        },
+        'additional_volumes': {
+            'count': SpecValidator(
+                type='integer',
+                min=0,
+                max=5,
+                default=2
+            ),
+            'type': SpecValidator(
+                type='choice',
+                choices=['pd-standard', 'pd-ssd'],
+                default='pd-ssd'
+            ),
+            'size': SpecValidator(
+                type='integer',
+                min=10,
+                max=65536,
+                default=100
+            )
+        }
+    },
     'postgres_server': {
         'instance_type': SpecValidator(
             type='choice',
             choices=[
                 'e2-standard-2', 'e2-standard-4', 'e2-standard-8',
                 'e2-standard-16', 'e2-standard-32', 'e2-highmem-2',
-                'e2-highmem-4', 'e2-highmem-8', 'e2-highmem-16'
+                'e2-highmem-4', 'e2-highmem-8', 'e2-highmem-16',
+                'n2-highmem-4', 'n2-highmem-8', 'n2-highmem-16',
+                'n2-highmem-32'
             ],
             default='e2-standard-4'
         ),
@@ -57,7 +100,7 @@ GCloudSpec = {
             'size': SpecValidator(
                 type='integer',
                 min=10,
-                max=16000,
+                max=65536,
                 default=100
             )
         }
@@ -81,7 +124,7 @@ GCloudSpec = {
             'size': SpecValidator(
                 type='integer',
                 min=10,
-                max=16000,
+                max=65536,
                 default=100
             )
         }
@@ -105,7 +148,7 @@ GCloudSpec = {
             'size': SpecValidator(
                 type='integer',
                 min=10,
-                max=16000,
+                max=65536,
                 default=50
             )
         }
@@ -129,7 +172,7 @@ GCloudSpec = {
             'size': SpecValidator(
                 type='integer',
                 min=10,
-                max=16000,
+                max=65536,
                 default=50
             )
         },
@@ -148,7 +191,7 @@ GCloudSpec = {
             'size': SpecValidator(
                 type='integer',
                 min=10,
-                max=16000,
+                max=65536,
                 default=300
             )
         }


### PR DESCRIPTION
Now that each supported cloud vendor is supported, no need for separate
ReferenceArchitectureOption per vendor.

Also updated the min/max storage options to match the vendor's allowed
min/max values.