### PR TITLE
Fix Unix socket dir

### DIFF
--- a/edbpotdeploy/data/ansible/roles/pot_setup/vars/PG.yml
+++ b/edbpotdeploy/data/ansible/roles/pot_setup/vars/PG.yml
@@ -7,4 +7,4 @@ pg_database: "postgres"
 pg_port: 5432
 pg_service: "postgresql-{{ pg_version }}"
 pg_unix_socket_directories: 
-  - "/var/run/postgres"
+  - "/var/run/postgresql"


### PR DESCRIPTION
edb-ansible collection configure by default the PostgreSQL Unix
socket path to /var/run/postgresql