### PR TITLE
Fix use of sku for Azure DB

### DIFF
--- a/edbdeploy/data/terraform/azure-db/environments/vm/vm.tf
+++ b/edbdeploy/data/terraform/azure-db/environments/vm/vm.tf
@@ -227,7 +227,7 @@ resource "azurerm_postgresql_server" "postgresql_server" {
   version    = var.pg_version
 
   storage_profile {
-    storage_mb = var.postgres_server["volume"]["size"]
+    storage_mb = var.postgres_server["size"]
     backup_retention_days        = 7
     geo_redundant_backup  = "Disabled"
   }
@@ -242,7 +242,7 @@ resource "azurerm_postgresql_database" "postgresql_db" {
   resource_group_name = var.resourcegroup_name
   server_name         = azurerm_postgresql_server.postgresql_server.name
   charset             = "utf8"
-  collation           = "English_United States.1252"
+  collation           = "C"
 }
 
 resource "azurerm_postgresql_firewall_rule" "postgresql-fw-rule" {

--- a/edbdeploy/project.py
+++ b/edbdeploy/project.py
@@ -1211,8 +1211,8 @@ class Project:
             'pg_version': env.postgres_version,
             'postgres_server': {
                 'count': ra['pg_count'],
-                'instance_type': pg['instance_type'],
-                'volume': pg['volume'],
+                'size': pg['size'],
+                'sku': pg['sku'],
             },
             'ssh_pub_key': self.ssh_pub_key,
             'ssh_priv_key': self.ssh_priv_key,

--- a/edbdeploy/spec/azure_db.py
+++ b/edbdeploy/spec/azure_db.py
@@ -38,30 +38,12 @@ AzureDBSpec = {
             ],
             default='B_Gen5_2'
         ),
-        'instance_type': SpecValidator(
-            type='choice',
-            choices=[
-                'Standard_A1_v2', 'Standard_A2_v2', 'Standard_A4_v2',
-                'Standard_A8_v2', 'Standard_A2m_v2', 'Standard_A4m_v2',
-                'Standard_A8m_v2', 'Standard_E4ds_v4', 'Standard_E8ds_v4',
-                'Standard_E16ds_v4', 'Standard_E32ds_v4'
-            ],
-            default='Standard_A4_v2'
-        ),
-        'volume': {
-            'storage_account_type': SpecValidator(
-                type='choice',
-                choices=['Premium_LRS', 'StandardSSD_LRS', 'Standard_LRS',
-                         'UltraSSD_LRS'],
-                default='Standard_LRS'
-            ),
-            'size': SpecValidator(
-                type='integer',
-                min=10,
-                max=16000,
-                default=100
-            )
-        }
+        'size': SpecValidator(
+            type='integer',
+            min=5120,
+            max=16777216,
+            default=5120
+        )
     },
     'pem_server': {
         'instance_type': SpecValidator(


### PR DESCRIPTION
The sku, or instance type, for the Azure DB Single System wasn't being
set correctly from the json configuration file.  This also cleans up
the spec validator for a valid storage size.