### PR TITLE
Support awscli version 1.x only

### DIFF
--- a/edbdeploy/cloud.py
+++ b/edbdeploy/cloud.py
@@ -20,7 +20,7 @@ class AWSCli:
     def __init__(self, bin_path=None):
         # aws CLI supported versions interval
         self.min_version = (0, 0, 0)
-        self.max_version = (2, 0, 45)
+        self.max_version = (1, 19, 97)
         # Path to look up for executable
         self.bin_path = None
         # Force aws CLI binary path if bin_path exists and contains


### PR DESCRIPTION
awscli versions 2.x are not and won't be published on pypi. Versions
1.x are still maintained so far, we stay on 1.x for now.