### PR TITLE
Fix ansible_ssh_pass setting

### DIFF
--- a/edbdeploy/project.py
+++ b/edbdeploy/project.py
@@ -1594,7 +1594,6 @@ class Project:
             repo_username=self.ansible_vars['repo_username'],
             repo_password=self.ansible_vars['repo_password'],
             pass_dir=os.path.join(self.project_path, '.edbpass'),
-            ansible_ssh_pass='vagrant'
         )
         if self.ansible_vars.get('efm_version'):
             extra_vars.update(dict(
@@ -1621,6 +1620,10 @@ class Project:
         # https://github.com/TPC-Council/HammerDB/issues/163
         if self.cloud == 'azure-db':
             extra_vars.update(dict(azure_db_hackery=True))
+
+        if self.cloud == 'vmware':
+            # Set SSH password
+            extra_vars.update(dict(ansible_ssh_pass='vagrant'))
 
         if pre_deploy_ansible:
 


### PR DESCRIPTION
Ansible variable ansible_ssh_pass must be only set when deploying
on vmware machines. For the other cloud vendors, deployment was
broken with the following message:

fatal: [primary1]: FAILED! => {"msg": "to use the 'ssh' connection
type with passwords, you must install the sshpass program"}