### PR TITLE
Support terraform 1.0.0 only

### DIFF
--- a/edbdeploy/terraform.py
+++ b/edbdeploy/terraform.py
@@ -22,7 +22,7 @@ class TerraformCli:
         self.environ = os.environ
         self.environ['TF_PLUGIN_CACHE_DIR'] = self.plugin_cache_dir
         # Terraform supported version interval
-        self.min_version = (0, 15, 3)
+        self.min_version = (1, 0, 0)
         self.max_version = (1, 0, 0)
         # Path to look up for executable
         self.bin_path = None


### PR DESCRIPTION
Due to some compatibily breaks in previous terraform versions, we
ensure to support only the 1.0.0 (and upper in the future) version.

Random failure exemple with 0.15.4:

```
Error: file provisioner error
with module.edb-db-cluster.null_resource.barman_copy_setup_volume_script[0],
on environments/ec2/ec2.tf line 271, in resource "null_resource" "barman_copy_setup_volume_script":
271:   provisioner "file" {
host for provisioner cannot be empty
```