### PR TITLE
Fix AWSRDSAuroraProject's __init__ method

### DIFF
--- a/edbdeploy/projects/aws_rds_aurora.py
+++ b/edbdeploy/projects/aws_rds_aurora.py
@@ -4,7 +4,7 @@ from ..password import get_password
 
 class AWSRDSAuroraProject(AWSRDSProject):
     def __init__(self, name, env, bin_path=None):
-        super(AWSRDSAuroraProject, self).__init__(
+        super(AWSRDSProject, self).__init__(
             'aws-rds-aurora', name, env, bin_path
         )
 


### PR DESCRIPTION
By calling the __init__() method of AWSRDSProject parent's (which is
Project) instead of AWSRDSAuroraProject's parent (which is
AWSRDSProject).

In both cases, __init__() signature was not the same.