### PR TITLE
Adding more capabilities for BDR Always On PoT

### DIFF
--- a/edbdeploy/data/ansible/EDB-Always-On.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On.yml
@@ -3,6 +3,8 @@
   name: Postgres deployment playbook for reference architecture EDB-Always-On
   become: yes
   gather_facts: yes
+  any_errors_fatal: True
+  max_fail_percentage: 0
 
   collections:
     - edb_devops.edb_postgres
@@ -14,6 +16,18 @@
         efm_version: 4.2
         pg_unix_socket_directories:
             - "/tmp"
+        pem_agent_package: "edb-pem-agent-8.0.1"
+        pem_server_packages: "edb-pem-server-8.1.1"
+
+  post_tasks:
+    - name: Make sure /tmp permissions are correct
+      file:
+        path: /tmp
+        owner: root
+        group: root
+        mode: 01777
+      when: "'pemserver' not in group_names"
+
   roles:
     - role: setup_repo
       when: "'pemserver' in group_names"

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/defaults/main.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/defaults/main.yml
@@ -37,3 +37,11 @@ pem_server_private_ip: ""
 pem_server_public_ip: ""
 primary_public_ip: ""
 user_expiry_date: ""
+
+pgbouncer_port: 6432
+pgbouncer_service: "pgbouncer"
+haproxy_service: "haproxy"
+haproxy_socket: "/var/run/haproxy.sock"
+pem_agent_bin_path: "/usr/edb/pem/agent/bin"
+pem_web_home_dir: "/usr/edb/pem/web"
+pem_server_service: "httpd"

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/os_configure_user.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/os_configure_user.yml
@@ -52,3 +52,23 @@
     mode: 0644
   become: yes
   when: group_names is subset(['pgbouncer'])
+
+- name: Add haproxy-pgbouncer-monitor.sh file
+  template:
+    src: haproxy-pgbouncer-monitor.sh.templates
+    dest: "{{ pem_agent_bin_path }}/haproxy-pgbouncer-monitor.sh"
+    owner: root
+    group: root
+    mode: 0755
+  become: yes
+  when: group_names is subset(['pgbouncer'])
+
+- name: Add barman-backup-monitor.py file
+  template:
+    src: barman-backup-monitor.py.template
+    dest: "{{ pem_agent_bin_path }}/barman-backup-monitor.py"
+    owner: root
+    group: root
+    mode: 0755
+  become: yes
+  when: group_names is subset(['barmanserver'])

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pem_server_certs.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pem_server_certs.yml
@@ -14,9 +14,9 @@
     - ansible_facts.services['firewalld.service'].status == 'enabled'
   become: yes
 
-- name: shutdown the httpd service
+- name: "Shutdown the {{ pem_server_service }} service"
   systemd:
-    name: httpd
+    name: "{{ pem_server_service }}"
     state: stopped
   become: yes
 
@@ -69,8 +69,8 @@
   loop_control:
     loop_var: line_item
 
-- name: start the httpd service
+- name: "Start the {{ pem_server_service }} service"
   systemd:
-    name: httpd
+    name: "{{ pem_server_service }}"
     state: started
   become: yes

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pem_server_probe_alert.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pem_server_probe_alert.yml
@@ -2,15 +2,87 @@
 
 - name: Copy the pem_probe_alert.sql
   template:
-    src: pem_probe_alert.sql
-    dest: "/tmp/pem_probe_alert.sql"
+    src: pem_bdr_probe.sql.template
+    dest: "/tmp/pem_bdr_probe.sql"
     owner: "{{ pg_owner }}"
     group: "{{ pg_owner }}"
     mode: 0640
   become: yes
 
-- name: Update pem server for unnecessary alerts/probes
+- name: Copy the pem_chart.sql
+  template:
+    src: pem_charts.sql.template
+    dest: "/tmp/pem_charts.sql"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_owner }}"
+    mode: 0640
+  become: yes
+
+- name: Copy the pem_dashboard.sql
+  template:
+    src: pem_dashboards.sql.template
+    dest: "/tmp/pem_dashboards.sql"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_owner }}"
+    mode: 0640
+  become: yes
+
+- name: Copy the data_view.sql
+  template:
+    src: data_view.sql
+    dest: "{{ pem_web_home_dir }}/pgadmin/pem/monitor/charts/templates/charts/sql/table/data_view.sql"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  become: yes
+
+- name: "Shutdown the {{ pem_server_service }} service"
+  systemd:
+    name: "{{ pem_server_service }}"
+    state: stopped
+  become: yes
+
+- name: "Start the {{ pem_server_service }} service"
+  systemd:
+    name: "{{ pem_server_service }}"
+    state: started
+  become: yes
+
+- name: Update pem server for necessary probes
   shell: >
-    psql -f /tmp/pem_probe_alert.sql pem
+    [[ ! -f /tmp/.pem_bdr_probe.sql.done ]] \
+    && {{ pg_bin_path }}/psql \
+        --file=/tmp/pem_bdr_probe.sql \
+        --dbname=pem \
+        --port={{ pg_port }} \
+        --host={{ pg_unix_socket_directories[0] }} \
+    && touch /tmp/.pem_bdr_probe.sql.done \
+    || echo "pem_bdr_probe.sql already executed"
+  become_user: "{{ pg_owner }}"
+  become: yes
+
+- name: Create pem haproxy, pgbouncer and barman charts
+  shell: >
+    [[ ! -f /tmp/.pem_charts.sql.done ]] \
+    && {{ pg_bin_path }}/psql \
+        --file=/tmp/pem_charts.sql \
+        --dbname=pem \
+        --port={{ pg_port }} \
+        --host={{ pg_unix_socket_directories[0] }} \
+    && touch /tmp/.pem_charts.sql.done \
+    || echo "pem_charts.sql already executed"
+  become_user: "{{ pg_owner }}"
+  become: yes
+
+- name: Create pem haproxy, pgbouncer and barman dashboards
+  shell: >
+    [[ ! -f /tmp/.pem_dashboards.sql.done ]] \
+    && {{ pg_bin_path }}/psql \
+        --file=/tmp/pem_dashboards.sql \
+        --dbname=pem \
+        --port={{ pg_port }} \
+        --host={{ pg_unix_socket_directories[0] }} \
+    && touch /tmp/.pem_dashboards.sql.done \
+    || echo "pem_dashboards.sql already executed"
   become_user: "{{ pg_owner }}"
   become: yes

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_pot_scripts.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_pot_scripts.yml
@@ -8,3 +8,12 @@
   become: yes
   become_user: "{{ pg_owner }}"
   ignore_errors: yes
+
+- name: Create exention edb_wait_states
+  shell: >
+       psql -h "{{ pg_unix_socket_directories[0] }}" \
+            -d "{{ pg_database }}" \
+            -c "CREATE EXTENSION IF NOT EXISTS edb_wait_states;"
+  become: yes
+  become_user: "{{ pg_owner }}"
+  ignore_errors: yes

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_user_pgpass.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_user_pgpass.yml
@@ -25,7 +25,7 @@
         create: yes
     pg_owner: "{{ os_project_user }}"
 
-- name: Add the pgpass for os_project_user for 6432 on the servers
+- name: Add the pgpass for os_project_user for "{{ pgbouncer_port }}" on the servers
   include_role:
     name: edb_devops.edb_postgres.manage_dbserver
     tasks_from: manage_pgpass
@@ -34,7 +34,7 @@
       - user: "{{ pg_project_user }}"
         password: "{{ input_password }}"
         create: yes
-    pg_port: 6432
+    pg_port: "{{ pgbouncer_port }}"
     pg_owner: "{{ os_project_user }}"
 
 - name: Generate the pg_ansible_user_password
@@ -63,7 +63,7 @@
         create: yes
     pg_owner: "{{ pg_ansible_user }}"
 
-- name: Add the pgpass for pg_ansible_user for 6432 on the servers
+- name: Add the pgpass for pg_ansible_user for "{{ pgbouncer_port }}" on the servers
   include_role:
     name: edb_devops.edb_postgres.manage_dbserver
     tasks_from: manage_pgpass
@@ -72,5 +72,5 @@
       - user: "{{ pg_ansible_user }}"
         password: "{{ input_password }}"
         create: yes
-    pg_port: 6432
+    pg_port: "{{ pgbouncer_port }}"
     pg_owner: "{{ pg_ansible_user }}"

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/barman-backup-monitor.py.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/barman-backup-monitor.py.template
@@ -1,0 +1,147 @@
+#!/usr/bin/python3
+
+import sys
+import json
+import os
+import subprocess
+import argparse
+from subprocess import CalledProcessError
+
+def print_to_stdout(*a):
+    """
+    function to print string to stdout
+    """
+
+    print(*a, file = sys.stdout)
+
+
+def print_to_stderr(*a):
+    """
+    function to print string to stderr
+    """
+
+    print(*a, file = sys.stderr)
+
+
+def exec_shell(args, environ=os.environ, cwd=None):
+    """
+    function to execute shell command
+    """
+    return subprocess.check_output(
+        ' '.join(args),
+        stderr=subprocess.STDOUT,
+        shell=True,
+        cwd=cwd,
+        env=environ
+    )
+
+
+def barman_backup_info():
+    """
+    Function to list the backups using barman
+    """
+
+    try:
+        output = exec_shell(
+                [
+                "barman",
+                "-f json",
+                "list-backup all"
+                ],
+                cwd="/tmp"
+            )  
+        data = json.loads(output.decode("utf-8"))
+    except CalledProcessError as e:
+        print_to_stderr("Failed to execute the command: %s", e.cmd)
+        print_to_stderr("Return code is %s", e.returncode)
+        print_to_stderr("Output: %s", e.output)
+
+    print_to_stdout("%s\t%s\t%s\t%s\t%s\t%s"
+                    %
+                    (
+                        "server_name",
+                        "backup_id",
+                        "end_time",
+                        "retention_status",
+                        "size",
+                        "status"
+                    )
+        )   
+
+    for backup_server in data:
+        for backup_server_info in data[backup_server]:
+            print_to_stdout("%s\t%s\t%s\t%s\t%s\t%s"
+                    %
+                    ( backup_server,
+                      backup_server_info['backup_id'],
+                      backup_server_info['end_time'],
+                      backup_server_info['retention_status'],
+                      backup_server_info['size'],
+                      backup_server_info['status'],
+                    )
+                )
+
+
+
+def barman_status():
+    """
+    function to find the status of the backup
+    """
+
+    try:
+        output = exec_shell(
+                [
+                "barman",
+                "-f json",
+                "check all"
+                ],
+                cwd="/tmp"
+            )  
+        data = json.loads(output.decode("utf-8"))
+    except CalledProcessError as e:
+        print_to_stderr("Failed to execute the command: %s", e.cmd)
+        print_to_stderr("Return code is %s", e.returncode)
+        print_to_stderr("Output: %s", e.output)
+
+    print_to_stdout("%s\t%s\t%s"
+        %
+        ("server_name",
+         "barman_component",
+         "status"
+        )
+    )
+
+    for backup_server in data:
+        for backup_status_info in data[backup_server]:
+            print_to_stdout("%s\t%s\t%s"
+                    %
+                    (
+                        backup_server,
+                        backup_status_info,
+                        data[backup_server][backup_status_info]['status']
+                    )
+                )
+
+
+
+monitor_parser = argparse.ArgumentParser(prog='PEM Agent barman-backup-monitor',
+                                     description='PEM Agent backup monitoring script')
+
+monitor_parser.add_argument('-s','--status',dest='status',
+                        action='store_true',
+                        help='Check the barman status. default: false'
+                       )
+
+monitor_parser.add_argument('-i','--backup-info',dest='backup_info',
+                        action='store_true',
+                        help='Check the barman backup_info. default: false'
+                       )
+monitor_barman_args = monitor_parser.parse_args()
+
+if monitor_barman_args.status:
+    barman_status()
+elif monitor_barman_args.backup_info:
+    barman_backup_info()
+else:
+    monitor_parser.print_help()
+ 

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/data_view.sql
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/data_view.sql
@@ -1,0 +1,63 @@
+WITH data_chart AS
+(
+   SELECT cid, tbl AS table_name, metrices FROM pem.data_chart
+   WHERE cid = (%(chart_id)s)::int4 AND cid>=257
+),
+probe_columns AS
+(
+    SELECT internal_name AS internal_name, display_name AS display_name
+    FROM pem.probe_column, data_chart
+    WHERE probe_id = (SELECT id FROM pem.probe, data_chart
+        WHERE internal_name = table_name AND NOT is_graphable)
+    AND internal_name = ANY(metrices)
+    UNION ALL
+    SELECT internal_name AS internal_name, display_name AS display_name
+    FROM pem.probe_column, data_chart
+    WHERE probe_id = (SELECT id FROM pem.probe, data_chart
+        WHERE internal_name = table_name AND is_graphable AND pit_by_default AND NOT calculate_pit)
+    AND internal_name = ANY(metrices)
+    UNION ALL
+    SELECT internal_name AS internal_name, display_name||'+' AS display_name
+    FROM pem.probe_column, data_chart
+    WHERE probe_id = (SELECT id FROM pem.probe, data_chart
+        WHERE internal_name = table_name AND is_graphable AND NOT pit_by_default AND calculate_pit)
+    AND internal_name = ANY(metrices)
+    UNION ALL
+    SELECT internal_name||'_pit' AS internal_name, display_name AS display_name
+    FROM pem.probe_column, data_chart
+    WHERE probe_id = (SELECT id FROM pem.probe, data_chart
+        WHERE internal_name = table_name AND is_graphable AND NOT pit_by_default AND calculate_pit)
+    AND internal_name = ANY(metrices)
+    UNION ALL
+    SELECT internal_name AS internal_name, display_name||'+' AS display_name
+    FROM pem.probe_column, data_chart
+    WHERE probe_id = (SELECT id FROM pem.probe, data_chart
+        WHERE internal_name = table_name AND is_graphable AND NOT pit_by_default AND NOT calculate_pit)
+    AND internal_name = ANY(metrices)
+)
+SELECT
+    d.tbl, d.metrices,
+    (
+    SELECT
+        array_agg(display_name)
+    FROM
+        (
+        SELECT
+            generate_series(
+                array_lower(metrices, 1),
+                array_upper(metrices, 1)
+            ) as idx
+        FROM
+            data_chart
+        ) AS FOO,
+        data_chart,
+        probe_columns
+    WHERE metrices[idx] = internal_name
+   ) AS display_labels,
+   d.orderby, d.orderdir, d.glimit, d.r_sys_obj, p.applies_to_id, p.target_type_id,
+   p.deleted
+FROM
+   pem.data_chart d
+   JOIN pem.probe p ON (d.tbl = p.internal_name)
+WHERE
+   d.cid = (%(chart_id)s)::int4

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/haproxy-pgbouncer-monitor.sh.templates
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/haproxy-pgbouncer-monitor.sh.templates
@@ -1,0 +1,208 @@
+#!/bin/bash
+
+################################################################################
+# Copyright EnterpriseDB Cooperation
+# All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in
+#      the documentation and/or other materials provided with the
+#      distribution.
+#    * Neither the name of PostgreSQL nor the names of its contributors
+#      may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#  Author: Vibhor Kumar
+#  E-mail ID: vibhor.aim@gmail.com
+################################################################################
+# verify any undefined shell variables
+set -u
+
+
+################################################################################
+# HAProxy environment
+################################################################################
+
+PGBIN="{{ pg_bin_path }}"
+PGPORT="{{ pg_port }}"
+PGOWNER="{{ pg_owner }}"
+HAPROXY_SOCKET="{{ haproxy_socket }}"
+HAPROXY_SERVICE="{{ haproxy_service }}"
+STATUS_MSG="status\tmessage"
+PGBOUNCER_SERVICE="{{ pgbouncer_service }}"
+PGBOUNCER_PORT="{{ pgbouncer_port }}"
+PYTHON3="/usr/bin/python3"
+
+export PGBIN HAPROXY_SOCKET HAPROXY_SERVICE PGPORT STATUS_MSG
+
+################################################################################
+# HAProxy is running or not
+################################################################################
+
+function is_haproxy_running()
+{
+    /bin/systemctl status ${HAPROXY_SERVICE} >/dev/null 2>&1
+    if [[ $? -ne 0 ]]
+    then
+        echo -e "${STATUS_MSG}"
+        echo -e "NOT OK\tHAProxy is not running"
+        exit 0
+    fi
+    ${PGBIN}/pg_isready -h 127.0.0.1 -p ${PGPORT} -q
+    if [[ $? -ne 0 ]]
+    then
+        echo -e "${STATUS_MSG}"
+        echo -e "NOT OK\tHAProxy is not redirecting connections"
+        exit 0
+    fi
+    echo -e "${STATUS_MSG}"
+    echo -e "OK\tHAProxy is running"
+    exit 0
+}
+
+################################################################################
+# pgbouncer is running or not
+################################################################################
+
+function is_pgbouncer_running()
+{
+    /bin/systemctl status ${PGBOUNCER_SERVICE} >/dev/null 2>&1
+    if [[ $? -ne 0 ]]
+    then
+        echo -e "${STATUS_MSG}"
+        echo -e "NOT OK\tPgbouncer is not running"
+        exit 0
+    fi
+    ${PGBIN}/pg_isready -h 127.0.0.1 -p ${PGBOUNCER_PORT} -q
+    if [[ $? -ne 0 ]]
+    then
+        echo -e "${STATUS_MSG}"
+        echo -e "NOT OK\tPgbouncer is not redirecting connections"
+        exit 0
+    fi
+    echo -e "${STATUS_MSG}"
+    echo -e "OK\tPgbouncer is running"
+    exit 0
+}
+
+################################################################################
+# pgbouncer stats
+################################################################################
+
+function pgbouncer_stats()
+{
+    /usr/bin/sudo -u ${PGOWNER} \
+        ${PGBIN}/psql \
+            --no-align \
+            --field-separator=$'\t' \
+            --port=6432 \
+            --username=pgbouncer \
+            --command='SHOW STATS;' \
+            --dbname=pgbouncer \
+            | grep -v "rows)"
+}
+
+################################################################################
+# HAProxy Stats
+################################################################################
+
+function haproxy_stats()
+{
+${PYTHON3} <<EOF
+
+import os
+import socket
+
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+    s.connect(os.environ.get('HAPROXY_SOCKET'))
+    s.send(b"show stat\n")
+    raw_data = s.recv(32768)
+    s.close()
+
+raw_data = raw_data.decode()[2:]
+raw_lines = raw_data.strip().split('\n')
+
+lines = []
+for raw_line in raw_lines[1:]:
+    # Replace empty values with zeros, as PEM dislikes NULLs with custom probes
+    line = ["0" if x == '' else x for x in raw_line.split(',')]
+    lines.append(line)
+
+print('%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s'
+     %
+     ( "proxy_name",
+       "service_name",
+       "queued_requests",
+       "current_sessions",
+       "total_sessions",
+       "bytes_in",
+       "bytes_out",
+       "status",
+       "check_status",
+       "avg_queue_time",
+       "avg_connect_time",
+       "avg_response_time"
+      )
+)
+
+for line in lines:
+    print('%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s'
+          %
+          ( line[0],
+            line[1],
+            line[2],
+            line[4],
+            line[7],
+            line[8],
+            line[9],
+            line[17],
+            line[36],
+            line[58],
+            line[59],
+            line[60]
+         )
+    )
+EOF
+}
+
+################################################################################
+# call the functions based on the functions
+################################################################################
+
+case "$1" in
+    --haproxy-health)
+        is_haproxy_running
+        ;;
+    --pgbouncer-health)
+        is_pgbouncer_running
+        ;;
+    --haproxy-stats)
+        haproxy_stats 2>/dev/null
+        ;;
+    --pgbouncer-stats)
+        pgbouncer_stats 2>/dev/null
+        ;;
+    *)
+        echo "ERROR: Unknown Option. Options are listed below"
+	echo "   --haproxy-health"
+	echo "   --pgbouncer-health"
+	echo "   --haproxy-stats"
+	echo "   --pgbouncer-stats"
+        ;;
+esac

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_bdr_probe.sql.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_bdr_probe.sql.template
@@ -1,0 +1,628 @@
+------------------------------------------------------------------------------
+-- SECTION: HAProxy
+------------------------------------------------------------------------------
+
+--
+-- Probe: haproxy_availability
+--
+-- NOTE: Ensure the path to pg_isready and the port number are correct in the
+--       code below. If not, update as appropriate. See:
+
+INSERT INTO pem.probe (
+    display_name,
+    internal_name,
+    collection_method,
+    target_type_id,
+    agent_capability,
+    enabled_by_default,
+    force_enabled,
+    default_execution_frequency,
+    default_lifetime,
+    any_server_version,
+    is_system_probe,
+    platform,
+    probe_code
+) VALUES (
+    'HAProxy Availability',
+    'haproxy_availability',
+    'b',
+    100,
+    NULL,
+    false,
+    false,
+    60,
+    90,
+    true,
+    false,
+    'unix',
+    $CODE$#!/bin/bash
+  /usr/edb/pem/agent/bin/haproxy-pgbouncer-monitor.sh --haproxy-health
+$CODE$
+);
+
+INSERT INTO pem.probe_column (
+    probe_id,
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+) SELECT
+    (SELECT id FROM pem.probe WHERE internal_name = 'haproxy_availability'),
+    v.internal_name,
+    v.display_name,
+    v.display_position,
+    v.classification,
+    v.sql_data_type,
+    v.unit_of_value,
+    v.calculate_pit,
+    v.discard_history,
+    v.pit_by_default,
+    v.is_graphable
+FROM
+    (VALUES
+            ('status', 'Status', 1, 'm', 'text', '', false, false, false, true),
+            ('message', 'Message', 2, 'm', 'text', '', false, false, false, false)
+        )
+v(
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+);
+
+--
+-- Probe: haproxy_stats
+--
+-- NOTE: Ensure the path to the stats socket is correct in the code below. If
+--       not, update as appropriate. See 's.connect("/var/run/haproxy.sock")'
+--
+
+INSERT INTO pem.probe (
+    display_name,
+    internal_name,
+    collection_method,
+    target_type_id,
+    agent_capability,
+    enabled_by_default,
+    force_enabled,
+    default_execution_frequency,
+    default_lifetime,
+    any_server_version,
+    is_system_probe,
+    platform,
+    probe_code
+) VALUES (
+    'HAProxy Stats',
+    'haproxy_stats',
+    'b',
+    100,
+    NULL,
+    false,
+    false,
+    300,
+    90,
+    true,
+    false,
+    'unix',
+    $CODE$#!/bin/bash
+ /usr/edb/pem/agent/bin/haproxy-pgbouncer-monitor.sh --haproxy-stats
+$CODE$
+);
+
+INSERT INTO pem.probe_column (
+    probe_id,
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+) SELECT
+    (SELECT id FROM pem.probe WHERE internal_name = 'haproxy_stats'),
+    v.internal_name,
+    v.display_name,
+    v.display_position,
+    v.classification,
+    v.sql_data_type,
+    v.unit_of_value,
+    v.calculate_pit,
+    v.discard_history,
+    v.pit_by_default,
+    v.is_graphable
+FROM
+    (VALUES
+            ('proxy_name', 'Proxy Name', 1, 'k', 'text', '', false, false, false, false),
+            ('service_name', 'Service Name', 2, 'k', 'text', '', false, false, false, false),
+            ('queued_requests', 'Queued Requests', 3, 'm', 'bigint', '', false, false, true, true),
+            ('current_sessions', 'Current Sessions', 4, 'm', 'bigint', '', false, false, true, true),
+            ('total_sessions', 'Total Sessions', 5, 'm', 'bigint', '', true, false, false, true),
+            ('bytes_in', 'Bytes In', 6, 'm', 'bigint', '', true, false, false, true),
+            ('bytes_out', 'Bytes Out', 7, 'm', 'bigint', '', true, false, false, true),
+            ('status', 'Status', 8, 'm', 'text', '', false, false, false, false),
+            ('check_status', 'Check Status', 9, 'm', 'text', '', false, false, false, false),
+            ('avg_queue_time', 'Average Queue Time', 10, 'm', 'bigint', '', false, false, true, true),
+            ('avg_connect_time', 'Average Connect Time', 11, 'm', 'bigint', '', false, false, true, true),
+            ('avg_response_time', 'Average Response Time', 12, 'm', 'bigint', '', false, false, true, true)
+        )
+v(
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+);
+
+------------------------------------------------------------------------------
+-- SECTION: PgBouncer
+------------------------------------------------------------------------------
+
+--
+-- Probe: pgbouncer_availability
+--
+-- NOTE: Ensure the path to pg_isready and the port number are correct in the
+--       code below. If not, update as appropriate.
+--
+
+
+INSERT INTO pem.probe (
+    display_name,
+    internal_name,
+    collection_method,
+    target_type_id,
+    agent_capability,
+    enabled_by_default,
+    force_enabled,
+    default_execution_frequency,
+    default_lifetime,
+    any_server_version,
+    is_system_probe,
+    platform,
+    probe_code
+) VALUES (
+    'PgBouncer Availability',
+    'pgbouncer_availability',
+    'b',
+    100,
+    NULL,
+    false,
+    false,
+    60,
+    90,
+    true,
+    false,
+    'unix',
+    $CODE$#!/bin/bash
+/usr/edb/pem/agent/bin/haproxy-pgbouncer-monitor.sh --pgbouncer-health
+$CODE$
+);
+
+INSERT INTO pem.probe_column (
+    probe_id,
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+) SELECT
+    (SELECT id FROM pem.probe WHERE internal_name = 'pgbouncer_availability'),
+    v.internal_name,
+    v.display_name,
+    v.display_position,
+    v.classification,
+    v.sql_data_type,
+    v.unit_of_value,
+    v.calculate_pit,
+    v.discard_history,
+    v.pit_by_default,
+    v.is_graphable
+FROM
+    (VALUES
+            ('status', 'Status', 1, 'm', 'text', '', false, false, false, false),
+            ('message', 'Message', 2, 'm', 'text', '', false, false, false, false)
+        )
+v(
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+);
+
+--
+-- Probe: pgbouncer_stats
+--
+--
+
+INSERT INTO pem.probe (
+    display_name,
+    internal_name,
+    collection_method,
+    target_type_id,
+    agent_capability,
+    enabled_by_default,
+    force_enabled,
+    default_execution_frequency,
+    default_lifetime,
+    any_server_version,
+    is_system_probe,
+    platform,
+    probe_code
+) VALUES (
+    'PgBouncer Stats',
+    'pgbouncer_stats',
+    'b',
+    100,
+    NULL,
+    false,
+    false,
+    300,
+    90,
+    true,
+    false,
+    'unix',
+    $CODE$#!/bin/bash
+/usr/edb/pem/agent/bin/haproxy-pgbouncer-monitor.sh --pgbouncer-stats
+$CODE$
+);
+
+INSERT INTO pem.probe_column (
+    probe_id,
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+) SELECT
+    (SELECT id FROM pem.probe WHERE internal_name = 'pgbouncer_stats'),
+    v.internal_name,
+    v.display_name,
+    v.display_position,
+    v.classification,
+    v.sql_data_type,
+    v.unit_of_value,
+    v.calculate_pit,
+    v.discard_history,
+    v.pit_by_default,
+    v.is_graphable
+FROM
+    (VALUES
+            ('database', 'Database', 1, 'k', 'text', '', false, false, false, false),
+            ('total_xact_count', 'Total Transaction Count', 2, 'm', 'bigint', '', true, false, false, true),
+            ('total_query_count', 'Current Sessions', 3, 'm', 'bigint', '', true, false, false, true),
+            ('total_received', 'Total Data Received', 4, 'm', 'bigint', 'Bytes', true, false, false, true),
+            ('total_sent', 'Total Data Sent', 5, 'm', 'bigint', 'Bytes', true, false, false, true),
+            ('total_xact_time', 'Total Transaction Duration', 6, 'm', 'bigint', 'uSecs', true, false, false, true),
+            ('total_query_time', 'Total Query Duration', 7, 'm', 'bigint', 'uSecs', true, false, false, true),
+            ('total_wait_time', 'Total Wait Time', 8, 'm', 'bigint', 'uSecs', true, false, false, true),
+            ('avg_xact_count', 'Average Transactions per Second', 9, 'm', 'bigint', '', false, false, true, true),
+            ('avg_query_count', 'Average Queries per Second', 10, 'm', 'bigint', '', false, false, true, true),
+            ('avg_recv', 'Average Data Received per Second', 11, 'm', 'bigint', 'Bytes', false, false, true, true),
+            ('avg_sent', 'Average Data Sent per Second', 12, 'm', 'bigint', 'Bytes', false, false, true, true),
+            ('avg_xact_time', 'Average Transaction Duration', 13, 'm', 'bigint', 'uSecs', false, false, true, true),
+            ('avg_query_time', 'Average Query Duration', 14, 'm', 'bigint', 'uSecs', false, false, true, true),
+            ('avg_wait_time', 'Average Wait Time', 15, 'm', 'bigint', 'uSecs', false, false, true, true)
+        )
+v(
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+);
+
+--
+-- Barman monitor
+--
+INSERT INTO pem.probe (
+    display_name,
+    internal_name,
+    collection_method,
+    target_type_id,
+    agent_capability,
+    enabled_by_default,
+    force_enabled,
+    default_execution_frequency,
+    default_lifetime,
+    any_server_version,
+    is_system_probe,
+    platform,
+    probe_code
+) VALUES (
+    'Barman Availability',
+    'barman_availability',
+    'b',
+    100,
+    NULL,
+    false,
+    false,
+    60,
+    90,
+    true,
+    false,
+    'unix',
+    $CODE$#!/bin/bash
+  /usr/edb/pem/agent/bin/barman-backup-monitor.py --status
+$CODE$
+);
+
+INSERT INTO pem.probe_column (
+    probe_id,
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+) SELECT
+    (SELECT id FROM pem.probe WHERE internal_name = 'barman_availability'),
+    v.internal_name,
+    v.display_name,
+    v.display_position,
+    v.classification,
+    v.sql_data_type,
+    v.unit_of_value,
+    v.calculate_pit,
+    v.discard_history,
+    v.pit_by_default,
+    v.is_graphable
+FROM
+    (VALUES
+            ('server_name', 'Server', 1, 'k', 'text', '', false, false, false, false),
+            ('barman_component', 'Barman Component', 2, 'k', 'text', '', false, false, false, false),
+          ('status', 'Status', 3, 'm', 'text', '', false, false, false, false)
+        )
+v(
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+);
+
+--
+-- Backup Information
+--
+
+INSERT INTO pem.probe (
+    display_name,
+    internal_name,
+    collection_method,
+    target_type_id,
+    agent_capability,
+    enabled_by_default,
+    force_enabled,
+    default_execution_frequency,
+    default_lifetime,
+    any_server_version,
+    is_system_probe,
+    platform,
+    probe_code
+) VALUES (
+    'Barman Backup Info',
+    'barman_backup_info',
+    'b',
+    100,
+    NULL,
+    false,
+    false,
+    60,
+    90,
+    true,
+    false,
+    'unix',
+    $CODE$#!/bin/bash
+  /usr/edb/pem/agent/bin/barman-backup-monitor.py --backup-info
+$CODE$
+);
+
+INSERT INTO pem.probe_column (
+    probe_id,
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+) SELECT
+    (SELECT id FROM pem.probe WHERE internal_name = 'barman_backup_info'),
+    v.internal_name,
+    v.display_name,
+    v.display_position,
+    v.classification,
+    v.sql_data_type,
+    v.unit_of_value,
+    v.calculate_pit,
+    v.discard_history,
+    v.pit_by_default,
+    v.is_graphable
+FROM
+    (VALUES
+          ('server_name', 'Server', 1, 'k', 'text', '', false, false, false, false),
+          ('backup_id', 'Barman Backup Id', 2, 'k', 'text', '', false, false, false, false),
+          ('end_time', 'End Time', 3, 'm', 'text', '', false, false, false, false),
+          ('retention_status', 'Retention Status', 4, 'm', 'text', '', false, false, false, false),
+          ('size', 'Size', 5, 'm', 'text', '', false, false, false, false),
+          ('status', 'Status', 6, 'm', 'text', '', false, false, false, false)
+        )
+v(
+    internal_name,
+    display_name,
+    display_position,
+    classification,
+    sql_data_type,
+    unit_of_value,
+    calculate_pit,
+    discard_history,
+    pit_by_default,
+    is_graphable
+);
+
+
+SELECT pem.create_data_and_history_tables();
+
+--
+-- Fix the bdr probe and disable some probes which are not needed
+--
+BEGIN;
+
+UPDATE
+    pem.probe
+SET
+    enabled_by_default = TRUE
+WHERE
+    internal_name NOT IN ('slony_replication', 'xdb_smr_mmr_replication', 'sql_protect')
+    AND target_type_id = 200
+    AND enabled_by_default = FALSE;
+
+UPDATE
+    pem.alert a
+SET
+    enabled = FALSE
+FROM
+    pem.alert_template t
+WHERE
+    a.template_id = t.id
+    AND (t.display_name ~ '^Last'
+        OR t.display_name ~ '^Largest index'
+        OR t.display_name = 'Database size in server'
+        OR t.display_name ~ 'Alert Errors')
+    AND t.is_auto_create = TRUE
+    AND a.enabled;
+
+--
+-- Fix BDR probe for replication slots
+--
+UPDATE pem.probe
+SET    probe_code = $SQL$
+SELECT node_group_name,
+       origin_name,
+       target_name,
+       slot_name,
+       active,
+       state,
+       (extract(epoch FROM (
+       CASE
+              WHEN write_lag = '' THEN '00:00:00'
+              ELSE write_lag
+       END)::interval))::DECIMAL AS write_lag,
+       (extract(epoch FROM (
+       CASE
+              WHEN flush_lag = '' THEN '00:00:00'
+              ELSE flush_lag
+       END)::interval))::DECIMAL AS flush_lag,
+       (extract(epoch FROM (
+       CASE
+              WHEN replay_lag = '' THEN '00:00:00'
+              ELSE replay_lag
+       END)::interval))::DECIMAL AS replay_lag,
+       sent_lag_bytes::NUMERIC,
+       write_lag_bytes::NUMERIC,
+       flush_lag_bytes::NUMERIC,
+       replay_lag_bytes::NUMERIC
+FROM   bdr.group_replslots_details
+WHERE  slot_name != '';$SQL$
+WHERE internal_name = 'bdr_group_replslots_details';
+
+UPDATE pem.probe
+SET    enabled_by_default = FALSE
+WHERE  internal_name IN ( 'efm_cluster_node_status',
+                          'bdr_node_replication_rates',
+                          'efm_cluster_info');
+UPDATE pem.alert
+SET    enabled = FALSE
+WHERE  template_id IN (SELECT id
+                       FROM   pem.alert_template
+                       WHERE  display_name ~* '^connections in idle state');
+
+--
+-- Make sure we allow enterprisedb as default user PEM server
+--
+
+UPDATE pem.server_option
+SET username = '{{ pg_owner }}'
+WHERE server_id = 1;
+
+--
+-- Disable HAProxy, Pgbouncer and Barman probes for
+-- where it's not applicable
+--
+INSERT INTO pem.probe_config_agent(probe_id, agent_id, enabled, execution_frequency, lifetime)
+SELECT p.id,
+       a.id as agent_id,
+       true,
+       p.default_execution_frequency,
+       p.default_lifetime
+FROM   pem.probe p, pem.agent a
+WHERE  p.internal_name LIKE '%pgbouncer%' AND a.description LIKE 'pgbouncer%'
+UNION
+SELECT p.id,
+       a.id as agent_id,
+       true,
+       p.default_execution_frequency,
+       p.default_lifetime
+FROM   pem.probe p, pem.agent a
+WHERE  p.internal_name LIKE '%haproxy%' AND a.description LIKE 'pgbouncer%'
+UNION
+SELECT p.id,
+       a.id as agent_id,
+       true,
+       p.default_execution_frequency,
+       p.default_lifetime
+FROM   pem.probe p, pem.agent a
+WHERE  p.internal_name LIKE '%barman%' AND a.description LIKE 'barman%';
+
+END;

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_charts.sql.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_charts.sql.template
@@ -1,0 +1,467 @@
+--
+-- HAProxy Availability Chart
+--
+
+INSERT INTO pem.chart(cid,
+                      type,
+                      level,
+                      name,
+                      descp,
+                      owner,
+                      shared,
+                      ref_cnt,
+                      reload)
+VALUES(1,
+       'TB',
+       (ARRAY[100])::int4[],
+       'HAProxy Availability',
+       'Chart for HAProxy Availability',
+       (SELECT oid
+        FROM pg_roles
+        WHERE rolname = current_user
+       )::oid,
+       ('{}')::oid[],
+       1,
+       120000
+);
+
+INSERT INTO pem.tbl_chart
+            (cid,
+             chart)
+SELECT id  AS cid,
+       'D' AS chart
+FROM   pem.chart
+WHERE  name ~* 'HAProxy Availability';
+
+INSERT INTO pem.data_chart
+            (
+                        cid,
+                        tbl,
+                        metrices,
+                        orderby,
+                        orderdir,
+                        glimit,
+                        r_sys_obj
+            )
+WITH probes_column_information AS
+(
+         SELECT   pc.probe_id,
+                  p.internal_name                tbl,
+                  ARRAY_AGG(pc.internal_name) AS metrices
+         FROM     pem.probe p
+         join     pem.probe_column pc
+         ON       (
+                           p.id=pc.probe_id)
+         WHERE    p.internal_name ~* 'haproxy_availability'
+         GROUP BY pc.probe_id,
+                  p.internal_name )
+SELECT c.id,
+       pc.tbl,
+       pc.metrices,
+       (NULL)::text[        ],
+       (NULL)::CHARACTER(1)[],
+       (NULL)::             int4,
+       (
+              SELECT applies_to_id >= 200
+              FROM   pem.probe
+              WHERE  id = pc.probe_id)::BOOLEAN
+FROM   pem.chart c,
+       probes_column_information pc
+WHERE  c.name ~* 'HAProxy Availability';
+
+--
+-- HAProxy Stats Chart
+--
+INSERT INTO pem.chart
+            (
+              cid,
+              TYPE,
+              LEVEL,
+              name,
+              descp,
+              owner,
+              SHARED,
+              ref_cnt,
+              reload
+            )
+VALUES( 1,
+        'TB',
+        (array[100])::int4[],
+        'HAProxy Statistics',
+        'Chart for HAProxy Statistics',
+        (
+          SELECT oid
+          FROM   pg_roles
+          WHERE  rolname = current_user)::oid,
+        ('{}')::oid[],
+        1,
+        120000
+);
+
+INSERT INTO pem.tbl_chart
+            (cid,
+             chart)
+SELECT id  AS cid,
+       'D' AS chart
+FROM   pem.chart
+WHERE  name ~* 'HAProxy Statistics';
+
+INSERT INTO pem.data_chart(
+                           cid,
+                           tbl,
+                           metrices,
+                           orderby,
+                           orderdir,
+                           glimit,
+                           r_sys_obj
+                          )
+WITH probes_column_information AS (
+    SELECT
+        probe_id,
+        tbl,
+        ARRAY_AGG(internal_name) AS metrices
+    FROM (
+        SELECT
+            pc.probe_id,
+            p.internal_name tbl,
+            pc.internal_name,
+            pc.display_position
+        FROM
+            pem.probe p
+            JOIN pem.probe_column pc ON (p.id = pc.probe_id)
+        WHERE
+            p.internal_name ~* 'haproxy_stats'
+            AND pc.internal_name IN ('check_status', 'proxy_name', 'service_name', 'status', 'total_sessions', 'queued_requests', 'current_sessions')
+        ORDER BY
+            pc.display_position)
+    GROUP BY
+        probe_id,
+        tbl
+)
+SELECT
+    c.id,
+    pc.tbl,
+    pc.metrices,
+    ARRAY['check_status']::text[],
+    ARRAY['A']::character (1)[],
+    200, (
+        SELECT
+            applies_to_id >= 200
+        FROM pem.probe
+    WHERE
+        id = pc.probe_id)::boolean
+FROM
+    pem.chart c,
+    probes_column_information pc
+WHERE
+    c.name ~* 'HAProxy Statistics';
+
+
+--
+-- Pgbouncer Availability Chart
+--
+INSERT INTO pem.chart (cid, type, level, name, descp, OWNER, shared, ref_cnt, reload)
+    VALUES (1, 'TB', (ARRAY[100])::int4[], 'Pgbouncer Availability', 'Chart for Pgbouncer Availability', (
+            SELECT
+                oid
+            FROM
+                pg_roles
+            WHERE
+                rolname = CURRENT_USER)::oid,
+            ('{}')::oid[],
+            1,
+            120000);
+
+INSERT INTO pem.tbl_chart (cid, chart)
+SELECT
+    id AS cid,
+    'D' AS chart
+FROM
+    pem.chart
+WHERE
+    name ~* 'Pgbouncer Availability';
+
+INSERT INTO pem.data_chart (cid, tbl, metrices, orderby, orderdir, glimit, r_sys_obj)
+WITH probes_column_information AS (
+    SELECT
+        pc.probe_id,
+        p.internal_name tbl,
+        array_agg(pc.internal_name) AS metrices
+    FROM
+        pem.probe p
+        JOIN pem.probe_column pc ON (p.id = pc.probe_id)
+    WHERE
+        p.internal_name ~* 'pgbouncer_availability'
+    GROUP BY
+        pc.probe_id,
+        p.internal_name
+)
+SELECT
+    c.id,
+    pc.tbl,
+    pc.metrices,
+    (NULL)::text[],
+    (NULL)::character (1)[],
+    (NULL)::int4,
+    (
+        SELECT
+            applies_to_id >= 200
+        FROM
+            pem.probe
+        WHERE
+            id = pc.probe_id)::boolean
+FROM
+    pem.chart c,
+    probes_column_information pc
+WHERE
+    c.name ~* 'Pgbouncer Availability';
+
+
+--
+-- Pgbouncer Statistics Chart
+--
+INSERT INTO pem.chart (cid, type, level, name, descp, owner, shared, ref_cnt, reload)
+    VALUES (1, 'TB', (ARRAY[100])::int4[], 'Pgbouncer Statistics', 'Chart for Pgbouncer Statistics', (
+            SELECT
+                oid
+            FROM
+                pg_roles
+            WHERE
+                rolname = CURRENT_USER)::oid,
+            ('{}')::oid[],
+            1,
+            120000);
+
+INSERT INTO pem.tbl_chart (cid, chart)
+SELECT
+    id AS cid,
+    'D' AS chart
+FROM
+    pem.chart
+WHERE
+    name ~* 'Pgbouncer Statistics';
+
+
+INSERT INTO pem.data_chart(
+                           cid,
+                           tbl,
+                           metrices,
+                           orderby,
+                           orderdir,
+                           glimit,
+                           r_sys_obj
+                          )
+WITH probes_column_information AS (
+    SELECT
+        probe_id,
+        tbl,
+        ARRAY_AGG(internal_name) AS metrices
+    FROM (
+        SELECT
+            pc.probe_id,
+            p.internal_name tbl,
+            pc.internal_name,
+            pc.display_position
+        FROM
+            pem.probe p
+            JOIN pem.probe_column pc ON (p.id = pc.probe_id)
+        WHERE
+            p.internal_name ~* 'pgbouncer_stats'
+            AND pc.internal_name IN ('database', 'total_query_count', 'total_wait_time', 'total_xact_count', 'avg_query_count', 'avg_query_time')
+        ORDER BY
+            pc.display_position
+            )
+    GROUP BY
+        probe_id,
+        tbl
+)
+SELECT
+    c.id,
+    pc.tbl,
+    pc.metrices,
+    ARRAY['database']::text[],
+    ARRAY['A']::character (1)[],
+    200, (
+        SELECT
+            applies_to_id >= 200
+        FROM pem.probe
+    WHERE
+        id = pc.probe_id)::boolean
+FROM
+    pem.chart c,
+    probes_column_information pc
+WHERE
+    c.name ~* 'Pgbouncer Statistics';
+
+--
+-- Barman Availability Chart
+--
+
+INSERT INTO pem.chart(cid,
+                      type,
+                      level,
+                      name,
+                      descp,
+                      owner,
+                      shared,
+                      ref_cnt,
+                      reload)
+VALUES(1,
+       'TB',
+       (ARRAY[100])::int4[],
+       'Barman Availability',
+       'Chart for Barman Availability',
+       (SELECT oid
+        FROM pg_roles
+        WHERE rolname = current_user
+       )::oid,
+       ('{}')::oid[],
+       1,
+       120000
+);
+
+
+INSERT INTO pem.tbl_chart
+            (cid,
+             chart)
+SELECT id  AS cid,
+       'D' AS chart
+FROM   pem.chart
+WHERE  name ~* 'Barman Availability';
+
+INSERT INTO pem.data_chart(
+                           cid,
+                           tbl,
+                           metrices,
+                           orderby,
+                           orderdir,
+                           glimit,
+                           r_sys_obj
+                          )
+WITH probes_column_information AS (
+    SELECT
+        probe_id,
+        tbl,
+        ARRAY_AGG(internal_name) AS metrices
+    FROM (
+        SELECT
+            pc.probe_id,
+            p.internal_name tbl,
+            pc.internal_name,
+            pc.display_position
+        FROM
+            pem.probe p
+            JOIN pem.probe_column pc ON (p.id = pc.probe_id)
+        WHERE
+            p.internal_name ~* 'barman_availability'
+        ORDER BY
+            pc.display_position
+            )
+    GROUP BY
+        probe_id,
+        tbl
+)
+SELECT
+    c.id,
+    pc.tbl,
+    pc.metrices,
+    ARRAY['barman_component']::text[],
+    ARRAY['A']::character (1)[],
+    200, (
+        SELECT
+            applies_to_id >= 200
+        FROM pem.probe
+    WHERE
+        id = pc.probe_id)::boolean
+FROM
+    pem.chart c,
+    probes_column_information pc
+WHERE
+    c.name ~* 'Barman Availability';
+
+
+--
+-- Barman Backup Info Chart
+--
+
+INSERT INTO pem.chart(cid,
+                      type,
+                      level,
+                      name,
+                      descp,
+                      owner,
+                      shared,
+                      ref_cnt,
+                      reload)
+VALUES(1,
+       'TB',
+       (ARRAY[100])::int4[],
+       'Barman Backup Detail',
+       'Chart for Barman Backup Detail',
+       (SELECT oid
+        FROM pg_roles
+        WHERE rolname = current_user
+       )::oid,
+       ('{}')::oid[],
+       1,
+       120000
+);
+
+INSERT INTO pem.tbl_chart
+            (cid,
+             chart)
+SELECT id  AS cid,
+       'D' AS chart
+FROM   pem.chart
+WHERE  name ~* 'Barman Backup Detail';
+
+
+INSERT INTO pem.data_chart(
+                           cid,
+                           tbl,
+                           metrices,
+                           orderby,
+                           orderdir,
+                           glimit,
+                           r_sys_obj
+                          )
+WITH probes_column_information AS (
+    SELECT
+        probe_id,
+        tbl,
+        ARRAY_AGG(internal_name) AS metrices
+    FROM (
+        SELECT
+            pc.probe_id,
+            p.internal_name tbl,
+            pc.internal_name,
+            pc.display_position
+        FROM
+            pem.probe p
+            JOIN pem.probe_column pc ON (p.id = pc.probe_id)
+        WHERE
+            p.internal_name ~* 'barman_backup_info'
+        ORDER BY
+            pc.display_position
+            )
+    GROUP BY
+        probe_id,
+        tbl
+)
+SELECT
+    c.id,
+    pc.tbl,
+    pc.metrices,
+    ARRAY['backup_id']::text[],
+    ARRAY['A']::character (1)[],
+    200, (
+        SELECT
+            applies_to_id >= 200
+        FROM pem.probe
+    WHERE
+        id = pc.probe_id)::boolean
+FROM
+    pem.chart c,
+    probes_column_information pc
+WHERE
+    c.name ~* 'Barman Backup Detail';

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.template
@@ -1,0 +1,213 @@
+--
+-- HAProxy and Pgbouncer Dashboard
+--
+INSERT INTO pem.dashboard (title, level, OWNER, descp, shared, font, font_size, is_ops_dashboard, show_title)
+    VALUES ('HAproxy and Pgbouncer Dashboard', 100, (
+            SELECT
+                oid
+            FROM pg_roles
+            WHERE
+                rolname = CURRENT_USER)::oid,
+        'Dashboard fro HAproxy and Pgbouncer Dashboard',
+        ('{}')::oid[],
+        (NULL)::text,
+        (NULL)::int4,
+        (FALSE)::boolean,
+        (FALSE)::boolean);
+
+INSERT INTO pem.dashboard_section (id, did, title)
+SELECT
+    1,
+    id,
+    'HAProxy Status'
+FROM
+    pem.dashboard
+WHERE
+    title ~* 'HAproxy and Pgbouncer Dashboard'
+UNION
+SELECT
+    2,
+    id,
+    'Pgbouncer Status'
+FROM
+    pem.dashboard
+WHERE
+    title ~* 'HAproxy and Pgbouncer Dashboard';
+
+INSERT INTO pem.dashboard_chart (did, sid, cid, INDEX, size, align, legend_type, show_chart_title)
+    SELECT
+        did, sid, cid, INDEX, 5 AS size,
+        2 align,
+        1 AS legend_type,
+        TRUE AS show_chart_title
+    FROM (
+        SELECT
+            did,
+            ds.id AS sid,
+            c.id AS cid,
+            0 AS index
+        FROM
+            pem.dashboard_section ds, pem.chart c
+        WHERE
+            ds.title ~* '^HAProxy Status' AND c.name ~* 'HAProxy Availability'
+        UNION
+        SELECT
+            did, ds.id AS sid,
+            c.id AS cid,
+            1 AS index
+        FROM
+            pem.dashboard_section ds, pem.chart c
+        WHERE
+            ds.title ~* '^HAProxy Status' AND c.name ~* 'HAProxy Statistics'
+        UNION
+        SELECT
+            did, ds.id AS sid,
+            c.id AS cid,
+            0 AS index
+        FROM
+            pem.dashboard_section ds, pem.chart c
+        WHERE
+            ds.title ~* '^Pgbouncer Status' AND c.name ~* 'Pgbouncer Availability'
+        UNION
+        SELECT
+            did, ds.id AS sid,
+            c.id AS cid,
+            1 AS index
+        FROM
+            pem.dashboard_section ds, pem.chart c
+        WHERE
+            ds.title ~* '^Pgbouncer Status' AND c.name ~* 'Pgbouncer Statistics') AS foo;
+
+
+--
+-- Barman Dashboard
+--
+INSERT INTO pem.dashboard (title, level, OWNER, descp, shared, font, font_size, is_ops_dashboard, show_title)
+    VALUES ('Barman Backup Dashboard', 100, (
+            SELECT
+                oid
+            FROM pg_roles
+            WHERE
+                rolname = CURRENT_USER)::oid,
+        'Dashboard for Barman Backup Dashboard',
+        ('{}')::oid[],
+        (NULL)::text,
+        (NULL)::int4,
+        (FALSE)::boolean,
+        (FALSE)::boolean);
+
+INSERT INTO pem.dashboard_section (id, did, title)
+SELECT
+    1,
+    id,
+    'Barman Backup Details'
+FROM
+    pem.dashboard
+WHERE
+    title ~* 'Barman Backup Dashboard';
+
+
+INSERT INTO pem.dashboard_chart (did, sid, cid, INDEX, size, align, legend_type, show_chart_title)
+    SELECT
+        did, sid, cid, INDEX, 5 AS size,
+        2 align,
+        1 AS legend_type,
+        TRUE AS show_chart_title
+    FROM (
+        SELECT
+            did,
+            ds.id AS sid,
+            c.id AS cid,
+            0 AS index
+        FROM
+            pem.dashboard_section ds, pem.chart c
+        WHERE
+            ds.title ~* '^Barman Backup Details' AND c.name ~* 'Barman Availability'
+        UNION
+        SELECT
+            did, ds.id AS sid,
+            c.id AS cid,
+            1 AS index
+        FROM
+            pem.dashboard_section ds, pem.chart c
+        WHERE
+            ds.title ~* 'Barman Backup Details' AND c.name ~* 'Barman Backup Detail') AS foo;
+
+
+--
+-- Create Data Center Groups
+--
+INSERT INTO pem.server_group (name)
+SELECT
+    unnest(ARRAY['Data Center I', 'Data Center II', 'Data Center III', 'Data Center I - PEM Agents', 'Data Center II - PEM Agents', 'Data Center III - PEM Agents']);
+
+--
+-- Group Servers based on data center
+--
+
+UPDATE
+    pem.server_options po
+SET
+    server_group_id = sg.id
+FROM
+    pem.server_group sg,
+    pem.server s
+WHERE
+    po.server_id = s.id
+    AND sg.name = 'Data Center I'
+    AND s.description IN ('epas1', 'epas2', 'epas3', 'barmandc1');
+
+UPDATE
+    pem.server_options po
+SET
+    server_group_id = sg.id
+FROM
+    pem.server_group sg,
+    pem.server s
+WHERE
+    po.server_id = s.id
+    AND sg.name = 'Data Center II'
+    AND s.description IN ('epas4', 'epas5','epas6', 'barmandc2');
+
+UPDATE
+    pem.server_options po
+SET
+    server_group_id = sg.id
+FROM
+    pem.server_group sg,
+    pem.server s
+WHERE
+    po.server_id = s.id
+    AND sg.name = 'Data Center III'
+    AND s.description IN ('epas7');
+
+--
+-- Group Agents based on data center
+--
+
+UPDATE
+    pem.agent a
+SET
+    group_id = sg.id
+FROM
+    pem.server_group sg
+WHERE sg.name = 'Data Center I - PEM Agents'
+    AND a.description IN ('epas1', 'epas2', 'epas3', 'barmandc1', 'pgbouncer1', 'pgbouncer2');
+
+UPDATE
+    pem.agent a
+SET
+    group_id = sg.id
+FROM
+    pem.server_group sg
+WHERE sg.name = 'Data Center II - PEM Agents'
+    AND a.description IN ('epas4', 'epas5','epas6', 'barmandc2', 'pgbouncer3', 'pgbouncer3');
+
+UPDATE
+    pem.agent a
+SET
+    group_id = sg.id
+FROM
+    pem.server_group sg
+WHERE sg.name = 'Data Center III - PEM Agents'
+    AND a.description IN ('epas7');

--- a/edbdeploy/data/terraform/aws/environments/ec2/outputs.tf
+++ b/edbdeploy/data/terraform/aws/environments/ec2/outputs.tf
@@ -222,6 +222,8 @@ cluster_vars:
   postgres_coredump_filter: '0xff'
   postgres_version: '13'
   postgresql_flavour: epas
+  postgres_conf_settings:
+     shared_preload_libraries: "'dbms_pipe, edb_gen, dbms_aq, edb_wait_states, sql-profiler, index_advisor, pg_stat_statements, pglogical, bdr'"
   pg_systemd_service_path: '/etc/systemd/system/postgres.service'
   pg_systemd_alias: 'edb-as-13.service'
   preferred_python_version: python3

--- a/edbdeploy/data/tpaexec/hooks/pre-initdb.yml
+++ b/edbdeploy/data/tpaexec/hooks/pre-initdb.yml
@@ -1,4 +1,14 @@
 ---
+- name: Install missing packages by tpaexec
+  package:
+    name:
+      - edb-as13-server-edb-modules
+      - edb-as13-server-indexadvisor
+      - edb-as13-server-sqlprofiler
+      - edb-as13-server-sqlprotect
+  when: >
+    'bdr' in role and 'primary' in role
+
 - name: Create /pgwal/wal directory
   file:
     path: "/pgwal/pg_wal"


### PR DESCRIPTION
Adding the following capability in aws-pot:
1. Probes and files for monitoring HAproxy, pgbouncer and Barman
2. Dashboard and charts for PEM
3. Environment configuration for client