### PR TITLE
BDR PoT pgbouncer integration

### DIFF
--- a/edbdeploy/data/ansible/EDB-Always-On.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On.yml
@@ -42,7 +42,17 @@
     - role: setup_pemserver
       when: "'pemserver' in group_names"
     - role: setup_pemagent
+      when: "'primary' in group_names"
+    - role: setup_pemagent
       vars:
         efm_enabled: False
-      when: "'pemserver' not in group_names"
+        force_register_db: False
+      when: "'barmanserver' in group_names"
+    - role: setup_pemagent
+      vars:
+        pg_service: pgbouncer
+        pg_port: 6432
+        efm_enabled: False
+        force_register_db: True
+      when: "'pgbouncer' in group_names"
     - role: bdr_pot_setup

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_pot_hba.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_pot_hba.yml
@@ -33,4 +33,3 @@
     tasks_from: manage_hba_conf
   vars:
     pg_hba_ip_addresses: "{{ pg_allow_ip_addresses }}"
-

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/haproxy-pgbouncer-monitor.sh.templates
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/haproxy-pgbouncer-monitor.sh.templates
@@ -48,7 +48,7 @@ STATUS_MSG="status\tmessage"
 PGBOUNCER_SERVICE="{{ pgbouncer_service }}"
 PGBOUNCER_PORT="{{ pgbouncer_port }}"
 PYTHON3="/usr/bin/python3"
-
+PGDATABASE="{{ pg_database }}"
 export PGBIN HAPROXY_SOCKET HAPROXY_SERVICE PGPORT STATUS_MSG
 
 ################################################################################
@@ -64,7 +64,7 @@ function is_haproxy_running()
         echo -e "NOT OK\tHAProxy is not running"
         exit 0
     fi
-    ${PGBIN}/pg_isready -h 127.0.0.1 -p ${PGPORT} -q
+    ${PGBIN}/pg_isready -h 127.0.0.1 -p ${PGPORT} -d ${PGDATABASE} -q
     if [[ $? -ne 0 ]]
     then
         echo -e "${STATUS_MSG}"
@@ -89,7 +89,7 @@ function is_pgbouncer_running()
         echo -e "NOT OK\tPgbouncer is not running"
         exit 0
     fi
-    ${PGBIN}/pg_isready -h 127.0.0.1 -p ${PGBOUNCER_PORT} -q
+    ${PGBIN}/pg_isready -h 127.0.0.1 -p ${PGBOUNCER_PORT} -d ${PGDATABASE} -q
     if [[ $? -ne 0 ]]
     then
         echo -e "${STATUS_MSG}"

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.template
@@ -155,7 +155,7 @@ FROM
 WHERE
     po.server_id = s.id
     AND sg.name = 'Data Center I'
-    AND s.description IN ('epas1', 'epas2', 'epas3', 'barmandc1');
+    AND s.description IN ('epas1', 'epas2', 'epas3', 'barmandc1','pgbouncer1', 'pgbouncer2');
 
 UPDATE
     pem.server_options po
@@ -167,7 +167,7 @@ FROM
 WHERE
     po.server_id = s.id
     AND sg.name = 'Data Center II'
-    AND s.description IN ('epas4', 'epas5','epas6', 'barmandc2');
+    AND s.description IN ('epas4', 'epas5','epas6', 'barmandc2', 'pgbouncer3','pgbouncer4');
 
 UPDATE
     pem.server_options po
@@ -211,3 +211,13 @@ FROM
     pem.server_group sg
 WHERE sg.name = 'Data Center III - PEM Agents'
     AND a.description IN ('epas7');
+
+--
+-- Change the default port of the pgbouncer
+--
+UPDATE
+   pem.server
+SET
+   port = 6432
+WHERE
+   description IN ('pgbouncer1', 'pgbouncer2', 'pgbouncer3', 'pgbouncer4');

--- a/edbdeploy/data/terraform/aws/environments/ec2/outputs.tf
+++ b/edbdeploy/data/terraform/aws/environments/ec2/outputs.tf
@@ -222,6 +222,7 @@ cluster_vars:
   postgres_coredump_filter: '0xff'
   postgres_version: '13'
   postgresql_flavour: epas
+  pgbouncer_pool_mode: transaction
   postgres_conf_settings:
      shared_preload_libraries: "'dbms_pipe, edb_gen, dbms_aq, edb_wait_states, sql-profiler, index_advisor, pg_stat_statements, pglogical, bdr'"
   pg_systemd_service_path: '/etc/systemd/system/postgres.service'


### PR DESCRIPTION
This commit allows the following:
1. Makes pgbouncer to run in transaction pool_mode
2. Register database through pgbouncer
4. Groups pgbouncer registered dbs in correct DCs