### PR TITLE
AWS BDR PoT final

### DIFF
--- a/edbdeploy/__init__.py
+++ b/edbdeploy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 
 def to_num(version):

--- a/edbdeploy/commands/aws_pot.py
+++ b/edbdeploy/commands/aws_pot.py
@@ -19,10 +19,10 @@ def subcommands(subparser):
     subcommand_parsers['configure'].add_argument(
         '-a', '--reference-architecture',
         dest='reference_architecture',
-        choices=POTReferenceArchitectureOption.choices,
-        default=POTReferenceArchitectureOption.default,
+        choices=AWSPOTReferenceArchitectureOption.choices,
+        default=AWSPOTReferenceArchitectureOption.default,
         metavar='<ref-arch-code>',
-        help=POTReferenceArchitectureOption.help
+        help=AWSPOTReferenceArchitectureOption.help
     )
     subcommand_parsers['configure'].add_argument(
         '--tpaexec-bin',

--- a/edbdeploy/data/terraform/aws/environments/ec2/outputs.tf
+++ b/edbdeploy/data/terraform/aws/environments/ec2/outputs.tf
@@ -379,6 +379,13 @@ instances:
   - barman
   - etcd
 %{endfor ~}
+%{if var.pem_server["count"] > 0 ~}
+- Name: pemserver1
+  node: ${var.bdr_server["count"] + var.bdr_witness_server["count"] + var.pooler_server["count"] + var.barman_server["count"] + 1}
+  location: BDRDC3
+  public_ip: ${aws_instance.pem_server[0].public_ip}
+  private_ip: ${aws_instance.pem_server[0].private_ip}
+%{endif ~}
 %{endif ~}
 EOT
 }

--- a/edbdeploy/options.py
+++ b/edbdeploy/options.py
@@ -23,6 +23,18 @@ class ReferenceArchitectureOption:
 
 
 class POTReferenceArchitectureOption:
+    choices = ['EDB-RA']
+
+    default = 'EDB-RA'
+    help = textwrap.dedent("""
+        Reference architecture code name. Allowed values are: EDB-RA for
+        a 3 Postgres nodes deployment with quorum base synchronous replication
+        and automatic failover, one backup server and one PEM monitoring
+        server.
+        Default: %(default)s
+    """)
+
+class AWSPOTReferenceArchitectureOption:
     choices = ['EDB-RA', 'EDB-Always-On']
 
     default = 'EDB-RA'
@@ -30,10 +42,12 @@ class POTReferenceArchitectureOption:
         Reference architecture code name. Allowed values are: EDB-RA for
         a 3 Postgres nodes deployment with quorum base synchronous replication
         and automatic failover, one backup server and one PEM monitoring
-        server, EDB-Always-On for deployment 6 Postgres nodes with BDR EE, one backup
-        server, 4 Pgbouncer/HAproxy servers and one PEM monitoring server.
+        server, EDB-Always-On for deployment 6 Postgres nodes and one witness node
+        with BDR EE, two backup servers, 4 Pgbouncer/HAproxy servers and
+        one PEM monitoring server.
         Default: %(default)s
     """)
+
 
 
 class ReferenceArchitectureOptionDBaaS:

--- a/edbdeploy/project.py
+++ b/edbdeploy/project.py
@@ -66,7 +66,7 @@ class Project:
         'virtualbox'
     )
     terraform_templates = ['variables.tf.template', 'tags.tf.template']
-    ansible_collection_name = 'edb_devops.edb_postgres:3.4.0'
+    ansible_collection_name = 'edb_devops.edb_postgres:3.5.0'
 
     def __init__(self, cloud, name, env, bin_path=None):
         self.env = env


### PR DESCRIPTION
This commit made the following changes:
1. Remove the EDB-Always-On architecture option from azure and gcloud.
2. Bumped the version to 3.5.0
3. Add pemserver1 in ssh_config file of tpaexec