### PR TITLE
Fixing typo in EDB-RA-3 architecture spec

### DIFF
--- a/edbdeploy/spec/reference_architecture.py
+++ b/edbdeploy/spec/reference_architecture.py
@@ -44,7 +44,7 @@ ReferenceArchitectureSpec = {
         'pem_server': True,
         'barman': True,
         'barman_server_count': 1,
-        'bdr_server_count': 1,
+        'bdr_server_count': 0,
         'bdr_witness_count': 0,
         'pooler_count': 3,
         'pooler_type': "pgpool2",


### PR DESCRIPTION
This commit fixes the EDB-RA-3 architecture issue due to typo EDB-RA-3 Specification