### PR TITLE
PoT route53 fixes and PEM server

### DIFF
--- a/edbdeploy/data/ansible/EDB-Always-On.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On.yml
@@ -49,12 +49,13 @@
     - role: setup_pemagent
       vars:
         efm_enabled: False
+        force_register_db: False
       when: "'barmanserver' in group_names"
     - role: setup_pemagent
       vars:
         pg_service: pgbouncer
         pg_port: 6432
         efm_enabled: false
-        force_register_db: true
+        force_register_db: True
       when: "'pgbouncer' in group_names"
     - role: bdr_pot_setup

--- a/edbdeploy/data/ansible/POT-Remove-Project-Route53.yml
+++ b/edbdeploy/data/ansible/POT-Remove-Project-Route53.yml
@@ -1,0 +1,60 @@
+- name: check the behavior
+  any_errors_fatal: True
+  max_fail_percentage: 0
+  gather_facts: no
+  hosts: localhost
+  become: no
+
+  tasks:
+     - name: Set facts
+       set_fact:
+          disable_logging: false
+          pem_server_public_ip: "{{ hostvars['pemserver1']['ansible_host'] }}"
+          route53_zone: "edbpov.io"
+          route53_record: "edbpov.io"
+          domain: "edbpov.io"
+          route_ip_addressess: []
+
+     - name: Get the route3 information
+       community.aws.route53:
+         aws_access_key: "{{ route53_access_key }}"
+         aws_secret_key: "{{ route53_secret }}"
+         state: get
+         zone: "{{ route53_zone }}"
+         record: "{{ route53_record }}"
+         type: A
+       register: rec
+
+     - name: Store the value of existsing ip address in a variable
+       set_fact:
+         route_ip_addressess: "{{ rec.set.ResourceRecords | map(attribute='Value') | unique | list }}"
+
+     - name: Remove the pem server ips in rec values
+       set_fact:
+           route_ip_addressess: "{{ route_ip_addressess | difference([pem_server_public_ip]) }}"
+       when:
+       - pem_server_public_ip in route_ip_addressess
+       - rec.set.ResourceRecords|length > 0
+
+     - name: Update a route53 for customer dns
+       community.aws.route53:
+         aws_access_key: "{{ route53_access_key }}"
+         aws_secret_key: "{{ route53_secret }}"
+         state: present
+         zone: "{{ route53_zone }}"
+         record: "{{ route53_record }}"
+         type: A
+         value: "{{ route_ip_addressess|join(',') }}"
+         overwrite: yes
+         wait: yes
+
+     - name: Remove a url entry in route53
+       community.aws.route53:
+          aws_access_key: "{{ route53_access_key }}"
+          aws_secret_key: "{{ route53_secret }}"
+          state: absent
+          zone: "{{ route53_zone }}"
+          record: "{{ project }}pem.{{ domain }}"
+          type: A
+          value: "{{ pem_server_public_ip }}"
+          wait: yes

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/update_route53.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/update_route53.yml
@@ -22,15 +22,12 @@
 
 - name: store the value of existsing ip address in a variable
   set_fact:
-    route_ip_addressess: "{{ route_ip_addressess + [record.Value] }}"
-  with_items: "{{ rec.set.ResourceRecords }}"
+    route_ip_addressess: "{{ rec.set.ResourceRecords | map(attribute='Value') | unique | list }}"
   when: rec.set.ResourceRecords|length > 0
-  loop_control:
-    loop_var: record
 
-- name: add the pem server ips in rec values
+- name: Add the pem server ips in rec values
   set_fact:
-        route_ip_addressess: "{{ route_ip_addressess + [pem_server_public_ip] }}"
+        route_ip_addressess: "{{ route_ip_addressess| union([pem_server_public_ip]) }}"
   when:
   - pem_server_public_ip not in route_ip_addressess
   - rec.set.ResourceRecords|length > 0

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.template
@@ -191,6 +191,11 @@ WHERE
     AND (s.description IN ('epas7')
     OR s.description IN ('epas7:5444'));
 
+DELETE
+FROM
+   pem.server
+WHERE description IN ('barmandc1','barmandc2');
+
 --
 -- Group Agents based on data center
 --
@@ -211,7 +216,7 @@ SET
 FROM
     pem.server_group sg
 WHERE sg.name = 'Data Center II - PEM Agents'
-    AND a.description IN ('epas4', 'epas5','epas6', 'barmandc2', 'pgbouncer3', 'pgbouncer3');
+    AND a.description IN ('epas4', 'epas5','epas6', 'barmandc2', 'pgbouncer3', 'pgbouncer4');
 
 UPDATE
     pem.agent a

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_probe_alert.sql
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_probe_alert.sql
@@ -69,4 +69,10 @@ WHERE  template_id IN (SELECT id
 UPDATE pem.server_option
 SET username = '{{ pg_owner }}'
 WHERE server_id = 1;
+
+UPDATE pem.probe
+SET default_lifetime = 5
+WHERE display_name ~* '^BDR'
+ AND display_name != 'BDR Conflict History Summary';;
+
 END;

--- a/edbdeploy/projects/aws_pot.py
+++ b/edbdeploy/projects/aws_pot.py
@@ -17,6 +17,8 @@ class AWSPOTProject(Project):
         self.terraform_path = os.path.join(self.terraform_share_path, 'aws')
         # POT only attributes
         self.ansible_pot_role = os.path.join(self.ansible_share_path, 'roles')
+        # Route53 entry removal playbook
+        self.ansible_route53_remove = os.path.join(self.ansible_share_path, 'POT-Remove-Project-Route53.yml')
         # TPAexec hooks path
         self.tpaexec_pot_hooks = os.path.join(self.tpaexec_share_path, 'hooks')
         self.custom_ssh_keys = {}
@@ -180,3 +182,5 @@ class AWSPOTProject(Project):
     def display_inventory(self, inventory_data):
         self.pot_display_inventory(inventory_data)
 
+    def destroy(self):
+        self.pot_destroy()

--- a/edbdeploy/projects/azure_pot.py
+++ b/edbdeploy/projects/azure_pot.py
@@ -14,6 +14,8 @@ class AzurePOTProject(Project):
         super(AzurePOTProject, self).__init__('azure-pot', name, env, bin_path)
         # Use Azure terraform code
         self.terraform_path = os.path.join(self.terraform_share_path, 'azure')
+        # Route53 entry removal playbook
+        self.ansible_route53_remove = os.path.join(self.ansible_share_path, 'POT-Remove-Project-Route53.yml')
         # POT only attributes
         self.ansible_pot_role = os.path.join(self.ansible_share_path, 'roles')
         # TPAexec hooks path
@@ -162,3 +164,6 @@ class AzurePOTProject(Project):
 
     def display_inventory(self, inventory_data):
         self.pot_display_inventory(inventory_data)
+
+    def destroy(self):
+        self.pot_destroy()

--- a/edbdeploy/projects/gcloud_pot.py
+++ b/edbdeploy/projects/gcloud_pot.py
@@ -18,6 +18,8 @@ class GCloudPOTProject(Project):
         self.terraform_path = os.path.join(self.terraform_share_path, 'gcloud')
         # POT only attributes
         self.ansible_pot_role = os.path.join(self.ansible_share_path, 'roles')
+        # Route53 entry removal playbook
+        self.ansible_route53_remove = os.path.join(self.ansible_share_path, 'POT-Remove-Project-Route53.yml')
         # TPAexec hooks path
         self.tpaexec_pot_hooks = os.path.join(self.tpaexec_share_path, 'hooks')
         self.custom_ssh_keys = {}
@@ -165,3 +167,6 @@ class GCloudPOTProject(Project):
 
     def display_inventory(self, inventory_data):
         self.pot_display_inventory(inventory_data)
+
+    def destroy(self):
+        self.pot_destroy()


### PR DESCRIPTION
Fixing the PoT route53 removal based on the destroy project. Also, ensuring BarmanDC servers should not be part of server binding.