### PR TITLE
Adding the ssh sub-command

### DIFF
--- a/edbdeploy/command.py
+++ b/edbdeploy/command.py
@@ -171,3 +171,16 @@ class Commander:
         )
         Project.create_cloud_tools_bin_dir()
         Project.setup_tools(self.env.cloud)
+
+    def ssh(self):
+        self._check_project_exists()
+
+        # Checking the node name and fetching SSH parameters
+        (host_address, ssh_user, ssh_priv_key) = self.project.prepare_ssh(
+            self.env.host
+        )
+
+        logging.info(
+            "Opening SSH session on %s (%s)", self.env.host, host_address
+        )
+        self.project.ssh(host_address, ssh_user, ssh_priv_key)

--- a/edbdeploy/commands/aws.py
+++ b/edbdeploy/commands/aws.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the aws command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'show', 'specs', 'setup', 'remove'
+        'passwords', 'provision', 'show', 'specs', 'setup', 'remove', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -151,4 +151,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/aws_pot.py
+++ b/edbdeploy/commands/aws_pot.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the aws command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'show', 'specs', 'setup', 'remove'
+        'passwords', 'provision', 'show', 'specs', 'setup', 'remove', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -142,4 +142,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/azure.py
+++ b/edbdeploy/commands/azure.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the azure command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'setup', 'show', 'specs', 'remove'
+        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -143,4 +143,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/azure_pot.py
+++ b/edbdeploy/commands/azure_pot.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the azure command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'setup', 'show', 'specs', 'remove'
+        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -175,4 +175,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/baremetal.py
+++ b/edbdeploy/commands/baremetal.py
@@ -9,7 +9,7 @@ def subcommands(subparser):
     # command
     available_subcommands = [
         'configure', 'deploy', 'display', 'list', 'logs', 'passwords', 'setup',
-        'show', 'specs', 'remove'
+        'show', 'specs', 'remove', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -129,4 +129,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/default.py
+++ b/edbdeploy/commands/default.py
@@ -51,6 +51,10 @@ DEFAULT_SUBCOMMANDS = {
         'help': 'Remove project',
         'project_argument': True,
     },
+    'ssh': {
+        'help': 'Open SSH connection to a node',
+        'project_argument': True,
+    },
 }
 
 def default_subcommand_parsers(subparser, available_subcommands):

--- a/edbdeploy/commands/gcloud.py
+++ b/edbdeploy/commands/gcloud.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the gcloud command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'setup', 'show', 'specs', 'remove'
+        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -159,4 +159,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/gcloud_pot.py
+++ b/edbdeploy/commands/gcloud_pot.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the gcloud command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'setup', 'show', 'specs', 'remove'
+        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -191,4 +191,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/virtualbox.py
+++ b/edbdeploy/commands/virtualbox.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the virtualbox
     # command
     available_subcommands = [
-        'configure', 'provision', 'deploy', 'destroy', 'remove', 'logs', 'list', 'display'
+        'configure', 'provision', 'deploy', 'destroy', 'remove', 'logs', 'list', 'display', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -171,4 +171,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )

--- a/edbdeploy/commands/vmware.py
+++ b/edbdeploy/commands/vmware.py
@@ -8,7 +8,7 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the vmwarewkstn
     # command
     available_subcommands = [
-        'configure', 'provision', 'deploy', 'destroy', 'remove', 'logs', 'list', 'display'
+        'configure', 'provision', 'deploy', 'destroy', 'remove', 'logs', 'list', 'display', 'ssh'
     ]
 
     # Get sub-commands parsers
@@ -173,4 +173,9 @@ def subcommands(subparser):
         dest='disable_pipelining',
         action='store_true',
         help="Disable Ansible pipelining."
+    )
+    subcommand_parsers['ssh'].add_argument(
+        metavar='<host-name>',
+        dest='host',
+        help="Node hostname"
     )


### PR DESCRIPTION
Usage: edb-deployment <cloud> ssh <project-name> <node-name>

node-name is the hostname (not the FQDN) of the target machine, can
be: pemserver1, pgsql1, pgsql2, etc...

The SSH user used is the one used to deploy the components.