### PR TITLE
Adding the get_ssh_keys sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,23 @@ Project tree deletion:
 $ edb-deployment <CLOUD_VENDOR> remove <PROJECT_NAME>
 ```
 
+Open SSH connection to one host of the project:
+```shell
+$ edb-deployment <CLOUD_VENDOR> ssh <PROJECT_NAME> <NODE_NAME>
+```
+
+Note: the node name list can be found by executing the `display` sub-command.
+It can be: `epas1`, `epas2`, `pemserver1`, etc...
+
+Get a copy of the SSH keys and the ssh_config file. The files are copied into
+the current directory:
+```shell
+$ edb-deployment <CLOUD_VENDOR> get_ssh_keys <PROJECT_NAME>
+```
+
+Note: This sub-command is only available for `aws-pot`, `azure-pot` and
+`gcloud-pot`.
+
 # License
 
 Original work Copyright 2019-2020, EnterpriseDB Corporation

--- a/edbdeploy/command.py
+++ b/edbdeploy/command.py
@@ -184,3 +184,7 @@ class Commander:
             "Opening SSH session on %s (%s)", self.env.host, host_address
         )
         self.project.ssh(host_address, ssh_user, ssh_priv_key)
+
+    def get_ssh_keys(self):
+        self._check_project_exists()
+        self.project.get_ssh_keys()

--- a/edbdeploy/commands/aws_pot.py
+++ b/edbdeploy/commands/aws_pot.py
@@ -8,7 +8,8 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the aws command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'show', 'specs', 'setup', 'remove', 'ssh'
+        'passwords', 'provision', 'show', 'specs', 'setup', 'remove', 'ssh',
+        'get_ssh_keys'
     ]
 
     # Get sub-commands parsers

--- a/edbdeploy/commands/azure_pot.py
+++ b/edbdeploy/commands/azure_pot.py
@@ -8,7 +8,8 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the azure command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh'
+        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh',
+        'get_ssh_keys'
     ]
 
     # Get sub-commands parsers

--- a/edbdeploy/commands/default.py
+++ b/edbdeploy/commands/default.py
@@ -55,6 +55,10 @@ DEFAULT_SUBCOMMANDS = {
         'help': 'Open SSH connection to a node',
         'project_argument': True,
     },
+    'get_ssh_keys': {
+        'help': 'Get a copy of the SSH private keys and configuration file',
+        'project_argument': True,
+    },
 }
 
 def default_subcommand_parsers(subparser, available_subcommands):

--- a/edbdeploy/commands/gcloud_pot.py
+++ b/edbdeploy/commands/gcloud_pot.py
@@ -8,7 +8,8 @@ def subcommands(subparser):
     # List of the sub-commands we want to be available for the gcloud command
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
-        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh'
+        'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh',
+        'get_ssh_keys'
     ]
 
     # Get sub-commands parsers

--- a/edbdeploy/specifications.py
+++ b/edbdeploy/specifications.py
@@ -136,17 +136,17 @@ def merge_user_spec(cloud, user_spec, reference_architecture=None):
     """
     Wrapper function for merging user specs. and default specs.
     """
-    if cloud == 'aws':
+    if cloud in ('aws', 'aws-pot'):
         cloud_spec = AWSSpec
     elif cloud == 'aws-rds':
         cloud_spec = AWSRDSSpec
     elif cloud == 'aws-rds-aurora':
         cloud_spec = AWSRDSAuroraSpec
-    elif cloud == 'azure':
+    elif cloud in ('azure', 'azure-pot'):
         cloud_spec = AzureSpec
     elif cloud == 'azure-db':
         cloud_spec = AzureDBSpec
-    elif cloud == 'gcloud':
+    elif cloud in ('gcloud', 'gcloud-pot'):
         cloud_spec = GCloudSpec
     elif cloud == 'gcloud-sql':
         cloud_spec = GCloudSQLSpec


### PR DESCRIPTION
This sub-command is only available for PoT deployments. It makes a copy of the SSH private keys, and the ssh_config file, into the current directory.