### PR TITLE
Adding the permision for barman execution as a project user

### DIFF
--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/os_configure_user.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/os_configure_user.yml
@@ -21,7 +21,7 @@
     group: root
     mode: 0440
   become: yes
-  when: group_names is subset(['primary', 'standby', 'pemserver'])
+  when: group_names is subset(['primary', 'standby', 'pemserver', 'barmanserver'])
 
 - name: Add pot aliases file
   template:

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/sudo_user.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/sudo_user.template
@@ -6,6 +6,7 @@
 
 {{ os_project_user }}  ALL=({{ pg_owner }})           NOPASSWD:   {{ pg_bin_path }}/pg_ctl 
 {{ os_project_user }}  ALL=({{ pg_owner }})           NOPASSWD:   /usr/bin/harpctl
+{{ os_project_user }}  ALL=(ALL)                      NOPASSWD:   /bin/barman
 
 # relax tty requirement for user '{{ os_project_user }}'
 Defaults:{{ pg_owner }} !requiretty


### PR DESCRIPTION
This PR allows a project user to execute commands like:
1. `sudo barman check all`
2. `sudo barman list-backup all`
3. `sudo barman list-backup all`
etc.