### PR TITLE
BDR PoT fixes for PEM

### DIFF
--- a/edbdeploy/data/ansible/EDB-Always-On-Platinum.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On-Platinum.yml
@@ -30,9 +30,11 @@
 
   roles:
     - role: setup_repo
-      when: "'pemserver' in group_names"
+      when: >
+        'pemserver' in group_names or 'pgbouncer' in group_names
     - role: install_dbserver
-      when: "'pemserver' in group_names"
+      when: >
+        'pemserver' in group_names or 'pgbouncer' in group_names
     - role: init_dbserver
       when: "'pemserver' in group_names"
     - role: manage_dbserver

--- a/edbdeploy/data/ansible/EDB-Always-On-Silver.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On-Silver.yml
@@ -30,9 +30,11 @@
 
   roles:
     - role: setup_repo
-      when: "'pemserver' in group_names"
+      when: >
+        'pemserver' in group_names or 'pgbouncer' in group_names
     - role: install_dbserver
-      when: "'pemserver' in group_names"
+      when: >
+        'pemserver' in group_names or 'pgbouncer' in group_names
     - role: init_dbserver
       when: "'pemserver' in group_names"
     - role: manage_dbserver

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pem_server_certs.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pem_server_certs.yml
@@ -54,6 +54,8 @@
       "to": "SSLCertificateFile '/etc/letsencrypt/live/{{ project }}pem.{{ domain }}/cert.pem'"
     - "from": "/usr/edb/pem/bin/../resources/server-pem.key"
       "to": "SSLCertificateKeyFile '/etc/letsencrypt/live/{{ project }}pem.{{ domain }}/privkey.pem'"
+    - "from": "ServerName localhost:8443"
+      "to": "ServerName 127.0.0.1:8443"
   loop_control:
     loop_var: line_item
 

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_create_user.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/pg_create_user.yml
@@ -63,3 +63,15 @@
          user: "{{ pg_project_user }}"
        - role: bdr_monitor
          user: "pemagent"
+       - role: bdr_superuser
+         user: "pemagent"
+       - role: bdr_read_all_conflicts
+         user: "pemagent"
+       - role: bdr_read_all_stats
+         user: "pemagent"
+       - role: bdr_superuser
+         user: "{{ pg_project_user }}"
+       - role: bdr_read_all_conflicts
+         user: "{{ pg_project_user }}"
+       - role: bdr_read_all_stats
+         user: "{{ pg_project_user }}"

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_bdr_probe.sql.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_bdr_probe.sql.template
@@ -489,6 +489,61 @@ SET    enabled_by_default = FALSE
 WHERE  internal_name IN ( 'efm_cluster_node_status',
                           'bdr_node_replication_rates',
                           'efm_cluster_info');
+
+UPDATE pem.probe
+SET probe_code = $SQL$SELECT node_name,
+       node_group_name,
+       peer_state_name,
+       peer_target_state_name,
+       (SELECT ARRAY_AGG(set_name)
+        FROM   bdr.replication_set) AS sub_repsets
+FROM   bdr.node_summary;$SQL$
+WHERE internal_name = 'bdr_node_summary';
+
+UPDATE pem.probe
+SET probe_code = $SQL$SELECT node_name,
+       postgres_version,
+       bdr_version AS pglogical_version,
+       bdr_version,
+       bdr_edition
+FROM   bdr.group_versions_details;$SQL$
+WHERE internal_name = 'bdr_group_versions_details';
+
+UPDATE pem.probe
+SET probe_code = $SQL$SELECT     werr.werr_worker_pid AS worker_pid,
+           bs.node_group_name,
+           bs.origin_name,
+           bs.source_name,
+           bs.target_name,
+           bs.sub_name,
+           werr.werr_worker_role                  AS worker_role,
+           wrn.rolname                            AS worker_role_name,
+           werr.werr_time                         AS error_time,
+           Age(CURRENT_TIMESTAMP, werr.werr_time) AS error_age,
+           werr.werr_message                      AS error_message,
+           werr.werr_context                      AS error_context_message,
+           werr.werr_remoterelid                  AS remoterelid,
+           bs.sub_id                              AS subwriter_id,
+           bs.sub_name                            AS subwriter_name
+FROM       bdr.worker_error werr
+LEFT JOIN  bdr.subscription_summary bs
+ON         werr.werr_subid = bs.sub_id
+CROSS JOIN lateral bdr.worker_role_id_name(werr.werr_worker_role) wrn(rolname);$SQL$
+WHERE internal_name = 'bdr_worker_errors';
+
+UPDATE pem.probe
+SET probe_code = $SQL$SELECT node_name,
+       camo_partner AS camo_partner_of,
+       node_name    AS camo_origin_for,
+       is_camo_partner_connected,
+       is_camo_partner_ready,
+       camo_transactions_resolved,
+       apply_lsn,
+       receive_lsn,
+       apply_queue_size
+FROM   bdr.group_camo_details;$SQL$
+WHERE internal_name = 'bdr_group_camo_details';
+
 UPDATE pem.alert
 SET    enabled = FALSE
 WHERE  template_id IN (SELECT id

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.platinum.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.platinum.template
@@ -224,6 +224,14 @@ WHERE sg.name = 'Data Center III - PEM Agents'
 UPDATE
    pem.server
 SET
-   port = 6432
+   port = 6432,
+   is_remote_monitoring = true
 WHERE
    description IN ('pgbouncer1', 'pgbouncer2', 'pgbouncer3', 'pgbouncer4');
+
+UPDATE pem.agent_server_binding asb
+SET    port=6432,
+       exclude_databases=array['postgres']
+from   pem.agent a
+WHERE  asb.agent_id = a.id
+AND    a.description LIKE 'pgbouncer%';

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.silver.template
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/pem_dashboards.sql.silver.template
@@ -174,6 +174,13 @@ FROM
    pem.server
 WHERE description IN ('barmandc1','barmandc2');
 
+UPDATE pem.agent_server_binding asb
+SET    port=6432,
+       exclude_databases=array['postgres']
+from   pem.agent a
+WHERE  asb.agent_id = a.id
+AND    a.description LIKE 'pgbouncer%';
+
 --
 -- Group Agents based on data center
 --
@@ -202,6 +209,7 @@ WHERE sg.name = 'Data Center II - PEM Agents'
 UPDATE
    pem.server
 SET
-   port = 6432
+   port = 6432,
+   is_remote_monitoring = true
 WHERE
    description IN ('pgbouncer1', 'pgbouncer2', 'pgbouncer3', 'pgbouncer4');

--- a/edbdeploy/data/templates/config.yml.j2
+++ b/edbdeploy/data/templates/config.yml.j2
@@ -10,8 +10,7 @@ cluster_vars:
   failover_manager: harp
   harp_consensus_protocol: etcd
   postgres_data_dir: /pgdata/pg_data
-  postgres_initdb_opts:
-  - --waldir=/pgwal/pg_wal
+  postgres_wal_dir: /pgwal/pg_wal
   postgres_coredump_filter: '0xff'
   postgres_version: '14'
   postgresql_flavour: epas
@@ -86,7 +85,6 @@ instances:
   backup: barmandc2
 {%   endif %}
   role:
-  - primary
   - bdr
 {%   if (bdr_server['id'] == 3 or bdr_server['id'] == 6) and vars['reference_architecture'] == 'EDB-Always-On-Platinum' %}
   - readonly
@@ -143,9 +141,7 @@ instances:
   public_ip:  {{ pooler_server['public_ip'] }}
   private_ip: {{ pooler_server['private_ip'] }}
   role:
-  - pgbouncer
   - harp-proxy
-  - etcd
 {% endfor %}
 {% for barman_server in servers['barman_server'] %}
 - Name: barmandc{{ barman_server['id']}}
@@ -159,7 +155,6 @@ instances:
   private_ip: {{ barman_server['private_ip'] }}
   role:
   - barman
-  - etcd
 {% endfor %}
 {% if servers.get('pem_server', []) | length > 0 %}
 - Name: pemserver1

--- a/edbdeploy/data/tpaexec/hooks/post-deploy.yml
+++ b/edbdeploy/data/tpaexec/hooks/post-deploy.yml
@@ -6,7 +6,6 @@
     state: absent
   when:
     - "'bdr' in role"
-    - "'primary' in role"
     - pg_systemd_alias is defined
     - pg_systemd_service_path is defined
 
@@ -18,7 +17,6 @@
     state: present
   when:
     - "'bdr' in role"
-    - "'primary' in role"
     - pg_systemd_alias is defined
     - pg_systemd_service_path is defined
 
@@ -26,7 +24,7 @@
   shell: >
     systemctl enable postgres
   when: >
-    'bdr' in role and 'primary' in role
+    'bdr' in role
 
 - name: "Start and enable the service"
   systemd:
@@ -34,7 +32,7 @@
     state: started
     enabled: true
   when: >
-    'bdr' in role and 'primary' in role
+    'bdr' in role
 
 - name: "Create harp-manager systemd unit directory used to store the override.conf file"
   ansible.builtin.file:
@@ -44,7 +42,7 @@
     group: root
     mode: '0755'
   when: >
-    'bdr' in role and 'primary' in role
+    'bdr' in role
 
 - name: "Create harp-proxy systemd unit directory used to store the override.conf file"
   ansible.builtin.file:
@@ -64,7 +62,7 @@
     group: root
     mode: '0644'
   when: >
-    'bdr' in role and 'primary' in role
+    'bdr' in role
 
 - name: "Override harp-proxy systemd unit"
   template:
@@ -80,7 +78,7 @@
   systemd:
     daemon_reload: yes
   when: >
-    ('bdr' in role and 'primary' in role) or ('harp-proxy' in role)
+    'bdr' in role or 'harp-proxy' in role
 
 - name: "Enable and start harp-manager systemd services"
   systemd:
@@ -88,7 +86,7 @@
     state: started
     enabled: true
   when: >
-    'bdr' in role and 'primary' in role
+    'bdr' in role
 
 - name: "Stop and disable pgbouncer systemd services"
   systemd:

--- a/edbdeploy/data/tpaexec/hooks/pre-initdb.yml
+++ b/edbdeploy/data/tpaexec/hooks/pre-initdb.yml
@@ -7,7 +7,7 @@
       - edb-as14-server-sqlprotect
       - edb-as14-server-edb_wait_states
   when: >
-    'bdr' in role and 'primary' in role
+    'bdr' in role
 
 - name: Create /pgwal/wal directory
   file:
@@ -15,4 +15,4 @@
     state: directory
     owner: "{{ postgres_user }}"
   when: >
-    'bdr' in role and 'primary' in role
+    'bdr' in role


### PR DESCRIPTION
This commit fixes the following for BDR PoT:
1. PEM default dashboards, which are not supporting BDR 4.0 due to probe code, we fixed that using ansible. We also hope the next release of PEM will have a fix for that
2. config.yml.j2 has been optimized as per the new structure supported by tpaexec, i.e., we don't need a primary role for bdr nodes.
3. pemagent has got extra monitoring permissions for BDR
4. As per the new HARP 2.0, we don't install edb-server packages/binaries on the pgbouncer node. Due to which custom dashboards were broken. We have modified the role to ensure edb-server packages are installed on the pgbouncer node
5. Enable pgbouncer monitoring as remote database monitoring.
6. Fix the problem with PEM server where localhost for 1PV6 may not redirect requests to the correct server.