### PR TITLE
update_route53_key new subcommand

### DIFF
--- a/edbdeploy/command.py
+++ b/edbdeploy/command.py
@@ -188,3 +188,9 @@ class Commander:
     def get_ssh_keys(self):
         self._check_project_exists()
         self.project.get_ssh_keys()
+
+    def update_route53_key(self):
+        self._check_project_exists()
+        self.project.pot_update_route53_key(
+            self.env.route53_access_key, self.env.route53_secret
+        )

--- a/edbdeploy/commands/aws_pot.py
+++ b/edbdeploy/commands/aws_pot.py
@@ -9,7 +9,7 @@ def subcommands(subparser):
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
         'passwords', 'provision', 'show', 'specs', 'setup', 'remove', 'ssh',
-        'get_ssh_keys'
+        'get_ssh_keys', 'update_route53_key'
     ]
 
     # Get sub-commands parsers
@@ -148,4 +148,20 @@ def subcommands(subparser):
         metavar='<host-name>',
         dest='host',
         help="Node hostname"
+    )
+    subcommand_parsers['update_route53_key'].add_argument(
+        '--route53-access-key',
+        dest='route53_access_key',
+        required=True,
+        type=str,
+        metavar='<route53-acccess-key>',
+        help="Route53 Access Key"
+    )
+    subcommand_parsers['update_route53_key'].add_argument(
+        '--route53-secret',
+        dest='route53_secret',
+        required=True,
+        type=str,
+        metavar='<route53-secret>',
+        help="Route53 Secret"
     )

--- a/edbdeploy/commands/azure_pot.py
+++ b/edbdeploy/commands/azure_pot.py
@@ -9,7 +9,7 @@ def subcommands(subparser):
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
         'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh',
-        'get_ssh_keys'
+        'get_ssh_keys', 'update_route53_key'
     ]
 
     # Get sub-commands parsers
@@ -181,4 +181,20 @@ def subcommands(subparser):
         metavar='<host-name>',
         dest='host',
         help="Node hostname"
+    )
+    subcommand_parsers['update_route53_key'].add_argument(
+        '--route53-access-key',
+        dest='route53_access_key',
+        required=True,
+        type=str,
+        metavar='<route53-acccess-key>',
+        help="Route53 Access Key"
+    )
+    subcommand_parsers['update_route53_key'].add_argument(
+        '--route53-secret',
+        dest='route53_secret',
+        required=True,
+        type=str,
+        metavar='<route53-secret>',
+        help="Route53 Secret"
     )

--- a/edbdeploy/commands/default.py
+++ b/edbdeploy/commands/default.py
@@ -59,6 +59,10 @@ DEFAULT_SUBCOMMANDS = {
         'help': 'Get a copy of the SSH private keys and configuration file',
         'project_argument': True,
     },
+    'update_route53_key': {
+        'help': 'Update project\'s route53 access key and secret',
+        'project_argument': True,
+    },
 }
 
 def default_subcommand_parsers(subparser, available_subcommands):

--- a/edbdeploy/commands/gcloud_pot.py
+++ b/edbdeploy/commands/gcloud_pot.py
@@ -9,7 +9,7 @@ def subcommands(subparser):
     available_subcommands = [
         'configure', 'deploy', 'destroy', 'display', 'list', 'logs',
         'passwords', 'provision', 'setup', 'show', 'specs', 'remove', 'ssh',
-        'get_ssh_keys'
+        'get_ssh_keys', 'update_route53_key'
     ]
 
     # Get sub-commands parsers
@@ -197,4 +197,20 @@ def subcommands(subparser):
         metavar='<host-name>',
         dest='host',
         help="Node hostname"
+    )
+    subcommand_parsers['update_route53_key'].add_argument(
+        '--route53-access-key',
+        dest='route53_access_key',
+        required=True,
+        type=str,
+        metavar='<route53-acccess-key>',
+        help="Route53 Access Key"
+    )
+    subcommand_parsers['update_route53_key'].add_argument(
+        '--route53-secret',
+        dest='route53_secret',
+        required=True,
+        type=str,
+        metavar='<route53-secret>',
+        help="Route53 Secret"
     )

--- a/edbdeploy/project.py
+++ b/edbdeploy/project.py
@@ -1673,3 +1673,10 @@ class Project:
             terraform.destroy(self.terraform_vars_file)
             self.update_state('terraform', 'DESTROYED')
             self.update_state('ansible', 'UNKNOWN')
+
+    def pot_update_route53_key(self, n_route53_access_key, n_route53_secret):
+        with AM("Updating route53 key and secret"):
+            self._load_ansible_vars()
+            self.ansible_vars['route53_access_key'] = n_route53_access_key
+            self.ansible_vars['route53_secret'] = n_route53_secret
+            self._save_ansible_vars()


### PR DESCRIPTION
This subcommand can be used to update project's route53 access key
and secret. Available only for *-pot.