### PR TITLE
Explicitly defines Harp repository

### DIFF
--- a/edbdeploy/data/templates/config.yml.j2
+++ b/edbdeploy/data/templates/config.yml.j2
@@ -24,6 +24,7 @@ cluster_vars:
   repmgr_failover: manual
   tpa_2q_repositories:
   - products/bdr4/release
+  - products/harp/release
   yum_repository_list:
   - EDB
   - EPEL


### PR DESCRIPTION
Without this change, Harp packages cannot be found and installed.