### PR TITLE
Rocky Linux support for PoT

### DIFF
--- a/edbdeploy/cloud.py
+++ b/edbdeploy/cloud.py
@@ -522,14 +522,20 @@ class GCloudCli:
 
     def check_image_availability(self, image):
         try:
-            output = exec_shell([
+            cmd = [
                 self.bin("gcloud"),
                 "compute",
                 "images",
                 "list",
                 "--filter=\"family=%s\"" % image,
                 "--format=json"
-            ])
+            ]
+            if image == 'rocky-linux-8':
+                cmd = cmd + [
+                        '--no-standard-images',
+                        '--project=rocky-linux-cloud'
+                        ]
+            output = exec_shell(cmd)
             result = json.loads(output.decode("utf-8"))
             logging.debug("Command output: %s", result)
             if len(result) == 0 or result[0]['status'] != 'READY':

--- a/edbdeploy/options.py
+++ b/edbdeploy/options.py
@@ -48,11 +48,11 @@ class ReferenceArchitectureOptionDBaaS:
 
 
 class OSOption:
-    choices = ['CentOS7', 'CentOS8', 'RedHat7', 'RedHat8', 'RockyLinux']
-    default = 'CentOS8'
+    choices = ['CentOS7', 'CentOS8', 'RedHat7', 'RedHat8', 'RockyLinux8']
+    default = 'RockyLinux8'
     help = textwrap.dedent("""
-        Operating system. Allowed values are: CentOS7, CentOS8, RedHat7 and
-        RedHat8. Default: %(default)s
+        Operating system. Allowed values are: CentOS7, CentOS8, RedHat7, RedHat8 and
+        RockyLinux8. Default: %(default)s
     """)
 
 

--- a/edbdeploy/projects/aws_pot.py
+++ b/edbdeploy/projects/aws_pot.py
@@ -26,7 +26,7 @@ class AWSPOTProject(Project):
         self.custom_ssh_keys = {}
         # Force PG version to 14 in POT env.
         self.postgres_version = '14'
-        self.operating_system = "CentOS8"
+        self.operating_system = "RockyLinux8"
 
     def configure(self, env):
         self.pot_configure(env)

--- a/edbdeploy/projects/azure_pot.py
+++ b/edbdeploy/projects/azure_pot.py
@@ -25,7 +25,7 @@ class AzurePOTProject(Project):
         self.custom_ssh_keys = {}
         # Force PG version to 14 in POT env.
         self.postgres_version = '14'
-        self.operating_system = "CentOS8"
+        self.operating_system = "RockyLinux8"
 
     def configure(self, env):
         self.pot_configure(env)

--- a/edbdeploy/projects/gcloud_pot.py
+++ b/edbdeploy/projects/gcloud_pot.py
@@ -27,7 +27,7 @@ class GCloudPOTProject(Project):
         self.custom_ssh_keys = {}
         # Force PG version to 14 in POT env.
         self.postgres_version = '14'
-        self.operating_system = "CentOS8"
+        self.operating_system = "RockyLinux8"
 
     def configure(self, env):
         self.pot_configure(env)

--- a/edbdeploy/spec/__init__.py
+++ b/edbdeploy/spec/__init__.py
@@ -64,10 +64,10 @@ DefaultAWSSpec = {
                 default='ec2-user'
             )
         },
-        'RockyLinux': {
+        'RockyLinux8': {
             'image': SpecValidator(
                 type='string',
-                default="Rocky*"
+                default="Rocky Linux 8.4*"
             ),
             'ssh_user': SpecValidator(
                 type='choice',
@@ -236,7 +236,7 @@ DefaultAzureSpec = {
             'sku': SpecValidator(type='string', default="8.2"),
             'ssh_user': SpecValidator(type='string', default='edbadm')
         },
-        'RockyLinux': {
+        'RockyLinux8': {
             'publisher': SpecValidator(type='string', default="Perforce"),
             'offer': SpecValidator(type='string', default="rockylinux8"),
             'sku': SpecValidator(type='string', default="8"),
@@ -374,7 +374,7 @@ DefaultGcloudSpec = {
             'image': SpecValidator(type='string', default="rhel-8"),
             'ssh_user': SpecValidator(type='string', default='edbadm')
         },
-        'RockyLinux': {
+        'RockyLinux8': {
             'image': SpecValidator(type='string', default="rocky-linux-8"),
             'ssh_user': SpecValidator(type='string', default='rocky')
         }


### PR DESCRIPTION
Adding RockyLinux support for PoT. This doesn't solve BDR PoT issue. However, enabled edb-deployment for RockyLinux and as soon as TPAExec supports Rocky Linux, BDR PoT will be automatically supported