### PR TITLE
BDR: force default_harp_proxy_mode to pgbouncer

### DIFF
--- a/edbdeploy/data/templates/config.yml.j2
+++ b/edbdeploy/data/templates/config.yml.j2
@@ -11,6 +11,7 @@ cluster_vars:
   harp_request_timeout: '250ms'
   harp_watch_poll_interval: '500ms'
   harp_consensus_protocol: etcd
+  default_harp_proxy_mode: pgbouncer
   postgres_data_dir: /pgdata/pg_data
   postgres_wal_dir: /pgwal/pg_wal
   postgres_coredump_filter: '0xff'


### PR DESCRIPTION
TPAexec v22.9 does not configure pgbouncer as the default proxy
mode for Harp.