### PR TITLE
Fix EDB-RA-1

### DIFF
--- a/edbdeploy/data/ansible/EDB-RA-1.yml
+++ b/edbdeploy/data/ansible/EDB-RA-1.yml
@@ -24,11 +24,5 @@
       when: "'setup_barman' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_pemagent
       when: "'setup_pemagent' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
-    - role: setup_dbt2_driver
-      when: "'setup_dbt2_driver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
-    - role: setup_dbt2_client
-      when: "'setup_dbt2_client' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
-    - role: setup_dbt2
-      when: "'setup_dbt2' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: autotuning
       when: "'autotuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"


### PR DESCRIPTION
EDB-RA-1 deployment was failing due to the inclusion of the
setup_dbt2 role. There is no need for DBT2 usage with this
architecture.

The error message was:
TASK [edb_devops.edb_postgres.setup_dbt2 : Gather DBT-2 driver addresses] ******
FAILED! => {"msg": "'dict object' has no attribute 'dbt2_driver'"}

Reported by: Sergio Romera