### PR TITLE
Update AWS filter used to fetch Rocky8 AMI ID

### DIFF
--- a/edbdeploy/cloud.py
+++ b/edbdeploy/cloud.py
@@ -117,7 +117,7 @@ class AWSCli:
                 self.bin("aws"),
                 "ec2",
                 "describe-images",
-                "--filters Name=name,Values=\"%s\"" % image,
+                "--filters Name=name,Values=\"%s\" Name=architecture,Values=\"x86_64\"" % image,
                 "--query 'sort_by(Images, &Name)[-1]'",
                 "--region %s" % region,
                 "--output json"

--- a/edbdeploy/spec/__init__.py
+++ b/edbdeploy/spec/__init__.py
@@ -56,7 +56,7 @@ DefaultAWSSpec = {
         'RockyLinux8': {
             'image': SpecValidator(
                 type='string',
-                default="Rocky Linux 8.4*"
+                default="Rocky-8*"
             ),
             'ssh_user': SpecValidator(
                 type='choice',


### PR DESCRIPTION
The previous filter led to wrong AMI ID in some cases.