### PR TITLE
Update virtualbox host-only networking

### DIFF
--- a/edbdeploy/projects/virtualbox.py
+++ b/edbdeploy/projects/virtualbox.py
@@ -502,7 +502,7 @@ class VirtualBoxProject(Project):
         # self.ansible_vars['operating_system'] when we support more than one
         # operating_system.
         image_name = 'mwedb/rockylinux8'
-        ip_prefix = '192.168.81.'
+        ip_prefix = '192.168.56.'
         # TODO: Make the starting ip address configurable in the event there are
         # multiple clusters to create.  We can't ask VirtualBox for unique IP
         # addresses, but we can control the sequence.


### PR DESCRIPTION
"On Linux, Mac OS X and Solaris Oracle VM VirtualBox will only allow IP addresses in 192.168.56.0/21 range to be assigned to host-only adapters."

https://www.virtualbox.org/manual/ch06.html#network_hostonly

An alternative is to edit the VirtualBox configuration file but I think we prefer to minimize user required configuration.