### PR TITLE
Update README-WIN

### DIFF
--- a/README-WIN.md
+++ b/README-WIN.md
@@ -82,6 +82,15 @@ Then restart WSL with the following command in an elevated Powershell:
 Restart-Service -Name "LxssManager"
 ```
 
+SSH key management in WSL can be done with `keychain`.  Here is an example of
+what to add to `.bashrc`:
+
+```shell
+/usr/bin/keychain -q --nogui $HOME/.ssh/private_key1
+/usr/bin/keychain -q --nogui $HOME/.ssh/private_key2
+source $HOME/.keychain/$HOST-sh
+```
+
 ## Manual `edb-deployment` Setup
 
 `edb-deployment` stores its files in `~/.edb-deployment` but the file system

--- a/README-WIN.md
+++ b/README-WIN.md
@@ -62,6 +62,26 @@ workaround a bug to enable the `vagrant ssh` command on Windows:
  vagrant plugin install virtualbox_WSL2
 ```
 
+Vagrant storing its insecure SSH key on an NTFS file system causes some
+additional issues with various Vagrant commands that try to ssh with the
+insecure private key.  Create the file `/etc/wsl.conf` in the WSL environment
+with the following contents:
+
+```
+# Enable extra metadata options by default
+[automount]
+enabled = true
+root = /mnt/
+options = "metadata,umask=77,fmask=11"
+mountFsTab = false
+```
+
+Then restart WSL with the following command in an elevated Powershell:
+
+```shell
+Restart-Service -Name "LxssManager"
+```
+
 ## Manual `edb-deployment` Setup
 
 `edb-deployment` stores its files in `~/.edb-deployment` but the file system


### PR DESCRIPTION
Additional setup is required for commands like 'vagrant ssh' to work under WSL.