### PR TITLE
Update virtualbox.py

### DIFF
--- a/edbdeploy/virtualbox.py
+++ b/edbdeploy/virtualbox.py
@@ -139,7 +139,7 @@ class VirtualBoxCli:
                 [
                     self.bin("vagrant"),
                     "init",
-                    "rockylinux/8",
+                    "generic/rocky8",
                 ],
                 environ=self.environ,
                 cwd=self.vagrant_project_path


### PR DESCRIPTION
Changes default box from `rocklylinux/8` to `generic/rocky8` due to issue #339