### PR TITLE
VirtualBox: template generation for Vagrantfile and specs support for os options, vagrantbox image and starting ipv4 for vms to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,13 @@ $ edb-deployment <CLOUD_VENDOR> <SUB_COMMAND> [<PROJECT_NAME>]
   * `gcloud`: Google Cloud
   * `gcloud-pot`: EDB POT (Proof Of Technology) on Google Cloud
   * `gcloud-sql`: Google Cloud SQL for PostgreSQL
+
+### Local Testing
+
   * `baremetal`: Baremetal servers and VMs
-  * `vmware`: VMWare Workstation
-  * `virtualbox`: Virtualbox
+  * `vmware`: [VMWare Workstation](./VMWARE.md)
+  * `virtualbox`: [Virtualbox](./VIRTUALBOX.md)
+    * [Windows Support through WSL2](./README-WIN.md)
 
 ## Sub-commands
 

--- a/VIRTUALBOX.md
+++ b/VIRTUALBOX.md
@@ -13,7 +13,16 @@ components before using it.
 
 ### Project initialization
 
-Project initialialization will done using the `configure` sub-command:
+1. Save spec file and override if needed
+    * `ipv4` - starting ip used to begin reserving a range
+      * must be within a network available in Virtualbox's Host Network Manager
+      * avoid conflicting with DHCP server even if disabled
+    * `available_os` - available operating system and its vagrantbox image for selection in `configure` subcommand
+```shell
+$ edb-deploy virtualbox spec > spec.json
+```
+
+2. Project initialialization will done using the `configure` sub-command:
 ```shell
 $ edb-deploy virtualbox configure <PROJECT_NAME> \
   -a <REFERENCE_ARCHITECTURE_CODE> \
@@ -22,7 +31,8 @@ $ edb-deploy virtualbox configure <PROJECT_NAME> \
   -v <PG_VERSION> \
   -u "<EDB_REPO_USERNAME>:<EDB_REPO_PASSWORD>" \
   -m <MEM_SIZE> \
-  -c <CPU_COUNT>
+  -c <CPU_COUNT> \
+  -s <SPEC_FILE>
 ```
 
 ***Notes:***
@@ -56,8 +66,6 @@ $ edb-deploy virtualbox configure <PROJECT_NAME> \
     EDB Packages repository credentials. **Required**.
 
   * `MEM_SIZE`
-
-    Amount of memory assigned to local machines. **Required**.
 
     Amount of memory assigned to local machines. **Required**.  
     **EDB-RA-1** deploys 3 servers: pem, barman and primary. 

--- a/VIRTUALBOX.md
+++ b/VIRTUALBOX.md
@@ -19,7 +19,7 @@ components before using it.
       * avoid conflicting with DHCP server even if disabled
     * `available_os` - available operating system and its vagrantbox image for selection in `configure` subcommand
 ```shell
-$ edb-deploy virtualbox spec > spec.json
+$ edb-deploy virtualbox specs > spec.json
 ```
 
 2. Project initialialization will done using the `configure` sub-command:

--- a/edbdeploy/data/templates/Vagrantfile.j2
+++ b/edbdeploy/data/templates/Vagrantfile.j2
@@ -1,5 +1,4 @@
 {% macro generate_generic_vms(virtual_machines, image_name) -%}
-{% if virtual_machines is defined %}
 {% for name, configs in virtual_machines.items() -%}
     config.vm.define "{{ name }}" do |{{ name }}|
         {{ name }}.vm.box = "{{ image_name }}"
@@ -7,7 +6,6 @@
         {{ name }}.vm.hostname = "{{ name }}"
     end
 {% endfor %}
-{% endif %}
 {% endmacro %}
 
 Vagrant.configure("2") do |config|
@@ -21,6 +19,8 @@ Vagrant.configure("2") do |config|
 
     config.vm.boot_timeout = 600
 
-{{ generate_generic_vms(vms, image_name) }}
+{% if vms is defined and image_name is defined %}
+    {{ generate_generic_vms(vms, image_name) }}
+{% endif %}
 
 end

--- a/edbdeploy/data/templates/Vagrantfile.j2
+++ b/edbdeploy/data/templates/Vagrantfile.j2
@@ -1,0 +1,26 @@
+{% macro generate_generic_vms(virtual_machines, image_name) -%}
+{% if virtual_machines is defined %}
+{% for name, configs in virtual_machines.items() -%}
+    config.vm.define "{{ name }}" do |{{ name }}|
+        {{ name }}.vm.box = "{{ image_name }}"
+        {{ name }}.vm.network "private_network", ip: "{{ configs['ip'] }}"
+        {{ name }}.vm.hostname = "{{ name }}"
+    end
+{% endfor %}
+{% endif %}
+{% endmacro %}
+
+Vagrant.configure("2") do |config|
+    config.ssh.insert_key = false
+    config.ssh.forward_agent = true
+
+    config.vm.provider "virtualbox" do |v|
+        v.memory = {{ mem_size }}
+        v.cpus = {{ cpu_count }}
+    end
+
+    config.vm.boot_timeout = 600
+
+{{ generate_generic_vms(vms, image_name) }}
+
+end

--- a/edbdeploy/projects/virtualbox.py
+++ b/edbdeploy/projects/virtualbox.py
@@ -242,9 +242,7 @@ class VirtualBoxProject(Project):
         Build Vagrantfile variables for jinja2 template
         Templates available inside of edbdeploy/data/templates
         """
-        # user_spec = self._load_cloud_spec(env)
-        os_image = env.cloud_spec['available_os'][env.operating_system] \
-            .get('image', 'mwedb/rockylinux8')
+        os_image = env.cloud_spec['available_os'][env.operating_system]['image']
         ip = ip_address(env.cloud_spec['ipv4'])
         self.vagrant_vars = {
             'mem_size': env.mem_size,
@@ -485,13 +483,13 @@ class VirtualBoxProject(Project):
                     % name
                 )
         for i in range(env.cloud_spec['dbt2_driver']['count']):
-            name = f"dbt2_driver_{i}"
+            name = f"dbt2driver{i}"
             try:
                 output = exec_shell(
                     [
                         self.bin("vagrant"),
                             "ssh",
-                            f"dbt2driver{i}",
+                            name,
                             "-c",
                             "\"ip address",
                             "show eth1",

--- a/edbdeploy/projects/virtualbox.py
+++ b/edbdeploy/projects/virtualbox.py
@@ -242,10 +242,10 @@ class VirtualBoxProject(Project):
         Build Vagrantfile variables for jinja2 template
         Templates available inside of edbdeploy/data/templates
         """
-        user_spec = self._load_user_spec(env)
-        os_image = user_spec['available_os'][env.operating_system] \
+        # user_spec = self._load_cloud_spec(env)
+        os_image = env.cloud_spec['available_os'][env.operating_system] \
             .get('image', 'mwedb/rockylinux8')
-        ip = ip_address(user_spec['ipv4'])
+        ip = ip_address(env.cloud_spec['ipv4'])
         self.vagrant_vars = {
             'mem_size': env.mem_size,
             'cpu_count': env.cpu_count,

--- a/edbdeploy/render.py
+++ b/edbdeploy/render.py
@@ -1,4 +1,3 @@
-from xmlrpc import server
 import yaml
 from jinja2 import Environment, FileSystemLoader
 import pathlib

--- a/edbdeploy/render.py
+++ b/edbdeploy/render.py
@@ -1,9 +1,10 @@
+from xmlrpc import server
 import yaml
 from jinja2 import Environment, FileSystemLoader
 import pathlib
 
 
-def render_template(template_name, servers_path, vars={}):
+def render_yaml_template(template_name, servers_path, vars={}):
     """
     Function in charge of generating file content based on:
     - a template file name, that template file must reside into data/templates.
@@ -29,12 +30,28 @@ def render_template(template_name, servers_path, vars={}):
 
 
 def build_inventory_yml(dest, servers_path, vars={}):
-    inventory = render_template('inventory.yml.j2', servers_path, vars)
+    inventory = render_yaml_template('inventory.yml.j2', servers_path, vars)
     with open(dest, 'w') as f:
         f.write(inventory)
 
 
 def build_config_yml(dest, servers_path, vars={}):
-    config = render_template('config.yml.j2', servers_path, vars)
+    config = render_yaml_template('config.yml.j2', servers_path, vars)
     with open(dest, 'w') as f:
         f.write(config)
+
+def render_vagrantfile_template(template_name, vars={}):
+    # Template directory is located in ./data/templates
+    current_dir = pathlib.Path(__file__).parent.resolve()
+    templates_dir = pathlib.PurePath.joinpath(current_dir, 'data/templates')
+    
+    file_loader = FileSystemLoader(str(templates_dir))
+    env = Environment(loader=file_loader, trim_blocks=True)
+    template = env.get_template(template_name)
+
+    return template.render(**vars)
+
+def build_vagrantfile(dest, vars={}, template_name='Vagrantfile.j2'):
+    vagrantfile = render_vagrantfile_template(template_name, vars)
+    with open(dest, 'w') as f:
+        f.write(vagrantfile)

--- a/edbdeploy/spec/virtualbox.py
+++ b/edbdeploy/spec/virtualbox.py
@@ -22,6 +22,15 @@ EDBRA1Spec = {
             default=0
         ),
     },
+    'available_os': {
+        'RockyLinux8': {
+            'image': SpecValidator(
+                type='string',
+                default='mwedb/rockylinux8',
+            ),
+        },
+    },
+    'ipv4': SpecValidator(type='ipv4', default='192.168.81.100'),
     'ssh_user': SpecValidator(type='string', default=None),
     'pg_data': SpecValidator(type='string', default=None),
     'pg_wal': SpecValidator(type='string', default=None),

--- a/edbdeploy/virtualbox.py
+++ b/edbdeploy/virtualbox.py
@@ -136,16 +136,6 @@ class VirtualBoxCli:
     def up(self):
         try:
             rc = exec_shell_live(
-                [
-                    self.bin("vagrant"),
-                    "init",
-                    "rockylinux/8",
-                ],
-                environ=self.environ,
-                cwd=self.vagrant_project_path
-            )
-
-            rc = exec_shell_live(
                 [   self.bin("vagrant"),
                     "up",
                 ],


### PR DESCRIPTION
Use of jinja2 generated template file for Vagrantfile
- spec file used to specify os/os-image and starting ipv4 for vms
- Vagrantfile.j2 template stored in data/templates and variables generated with spec file or environment variables

Closes #345
Resolves #339
Resolves #341 
