### PR TITLE
bump GCloudCli max_version

### DIFF
--- a/edbdeploy/cloud.py
+++ b/edbdeploy/cloud.py
@@ -453,7 +453,7 @@ class GCloudCli:
     def __init__(self, bin_path=None):
         # gcloud CLI supported versions interval
         self.min_version = (0, 0, 0)
-        self.max_version = (367, 0, 0)
+        self.max_version = (406, 0, 0)
         # Path to look up for executable
         self.bin_path = None
         # Force gcloud CLI binary path if bin_path exists and contains


### PR DESCRIPTION
`gcloud auth login <LOGIN_EMAIL> --no-launch-browser` error while trying to retrieve token when using older CLI version installed w/ `edb-deployment gcloud setup`

```
Authorization Error
Error 400: invalid_request

The version of the app you're using doesn't include the latest security features to keep you protected. Please make sure to download from a trusted source and update to the latest, most secure version.
```