### PR TITLE
VirtualBox: template generation for Vagrantfile and specs support for os options, vagrantbox image and starting ipv4 for vms to use - Rework

### DIFF
--- a/README-WIN.md
+++ b/README-WIN.md
@@ -58,7 +58,7 @@ Install additional plugins from the shell to enable shared folders and
 workaround a bug to enable the `vagrant ssh` command on Windows:
 
 ```shell
- vagrant plugin install vagrant_guest
+ vagrant plugin install vagrant-vbguest
  vagrant plugin install virtualbox_WSL2
 ```
 
@@ -86,9 +86,9 @@ SSH key management in WSL can be done with `keychain`.  Here is an example of
 what to add to `.bashrc`:
 
 ```shell
-/usr/bin/keychain -q --nogui $HOME/.ssh/private_key1
+/usr/bin/keychain -q --nogui $HOME/.vagrant.d/insecure_private_key
 /usr/bin/keychain -q --nogui $HOME/.ssh/private_key2
-source $HOME/.keychain/$HOST-sh
+source $HOME/.keychain/$HOSTNAME-sh
 ```
 
 ## Manual `edb-deployment` Setup

--- a/README-WIN.md
+++ b/README-WIN.md
@@ -88,7 +88,7 @@ what to add to `.bashrc`:
 ```shell
 /usr/bin/keychain -q --nogui $HOME/.vagrant.d/insecure_private_key
 /usr/bin/keychain -q --nogui $HOME/.ssh/private_key2
-source $HOME/.keychain/$HOSTNAME-sh
+source $HOME/.keychain/$(hostname)-sh
 ```
 
 ## Manual `edb-deployment` Setup

--- a/README.md
+++ b/README.md
@@ -132,9 +132,13 @@ $ edb-deployment <CLOUD_VENDOR> <SUB_COMMAND> [<PROJECT_NAME>]
   * `gcloud`: Google Cloud
   * `gcloud-pot`: EDB POT (Proof Of Technology) on Google Cloud
   * `gcloud-sql`: Google Cloud SQL for PostgreSQL
+
+### Local Testing
+
   * `baremetal`: Baremetal servers and VMs
-  * `vmware`: VMWare Workstation
-  * `virtualbox`: Virtualbox
+  * `vmware`: [VMWare Workstation](./VMWARE.md)
+  * `virtualbox`: [Virtualbox](./VIRTUALBOX.md)
+    * [Windows Support through WSL2](./README-WIN.md)
 
 ## Sub-commands
 

--- a/VIRTUALBOX.md
+++ b/VIRTUALBOX.md
@@ -13,7 +13,16 @@ components before using it.
 
 ### Project initialization
 
-Project initialialization will done using the `configure` sub-command:
+1. Save spec file and override if needed
+    * `ipv4` - starting ip used to begin reserving a range
+      * must be within a network available in Virtualbox's Host Network Manager
+      * avoid conflicting with DHCP server even if disabled
+    * `available_os` - available operating system and its vagrantbox image for selection in `configure` subcommand
+```shell
+$ edb-deploy virtualbox specs > spec.json
+```
+
+2. Project initialialization will done using the `configure` sub-command:
 ```shell
 $ edb-deploy virtualbox configure <PROJECT_NAME> \
   -a <REFERENCE_ARCHITECTURE_CODE> \
@@ -22,7 +31,8 @@ $ edb-deploy virtualbox configure <PROJECT_NAME> \
   -v <PG_VERSION> \
   -u "<EDB_REPO_USERNAME>:<EDB_REPO_PASSWORD>" \
   -m <MEM_SIZE> \
-  -c <CPU_COUNT>
+  -c <CPU_COUNT> \
+  -s <SPEC_FILE>
 ```
 
 ***Notes:***
@@ -56,8 +66,6 @@ $ edb-deploy virtualbox configure <PROJECT_NAME> \
     EDB Packages repository credentials. **Required**.
 
   * `MEM_SIZE`
-
-    Amount of memory assigned to local machines. **Required**.
 
     Amount of memory assigned to local machines. **Required**.  
     **EDB-RA-1** deploys 3 servers: pem, barman and primary. 

--- a/edbdeploy/data/templates/Vagrantfile.j2
+++ b/edbdeploy/data/templates/Vagrantfile.j2
@@ -1,9 +1,9 @@
 {% macro generate_generic_vms(virtual_machines, image_name) -%}
 {% for name, configs in virtual_machines.items() -%}
-    config.vm.define "{{ name }}" do |{{ name }}|
-        {{ name }}.vm.box = "{{ image_name }}"
-        {{ name }}.vm.network "private_network", ip: "{{ configs['ip'] }}"
-        {{ name }}.vm.hostname = "{{ name }}"
+    config.vm.define "{{ name }}" do | v |
+        v.vm.box = "{{ image_name }}"
+        v.vm.network "private_network", ip: "{{ configs['public_ip'] }}"
+        v.vm.hostname = "{{ configs['name'] }}"
     end
 {% endfor %}
 {% endmacro %}

--- a/edbdeploy/data/templates/Vagrantfile.j2
+++ b/edbdeploy/data/templates/Vagrantfile.j2
@@ -1,12 +1,13 @@
-{% macro generate_generic_vms(virtual_machines, image_name) -%}
-{% for name, configs in virtual_machines.items() -%}
+{%- macro generate_generic_vms(virtual_machines, image_name) %}
+{%- for name, configs in virtual_machines.items() %}
     config.vm.define "{{ name }}" do | v |
         v.vm.box = "{{ image_name }}"
         v.vm.network "private_network", ip: "{{ configs['public_ip'] }}"
         v.vm.hostname = "{{ configs['name'] }}"
     end
-{% endfor %}
-{% endmacro %}
+
+{% endfor -%}
+{% endmacro -%}
 
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
@@ -19,8 +20,8 @@ Vagrant.configure("2") do |config|
 
     config.vm.boot_timeout = 600
 
-{% if vms is defined and image_name is defined %}
+{% if vms is defined and image_name is defined -%}
     {{ generate_generic_vms(vms, image_name) }}
-{% endif %}
+{%- endif -%}
 
 end

--- a/edbdeploy/data/templates/Vagrantfile.j2
+++ b/edbdeploy/data/templates/Vagrantfile.j2
@@ -1,0 +1,26 @@
+{% macro generate_generic_vms(virtual_machines, image_name) -%}
+{% for name, configs in virtual_machines.items() -%}
+    config.vm.define "{{ name }}" do |{{ name }}|
+        {{ name }}.vm.box = "{{ image_name }}"
+        {{ name }}.vm.network "private_network", ip: "{{ configs['ip'] }}"
+        {{ name }}.vm.hostname = "{{ name }}"
+    end
+{% endfor %}
+{% endmacro %}
+
+Vagrant.configure("2") do |config|
+    config.ssh.insert_key = false
+    config.ssh.forward_agent = true
+
+    config.vm.provider "virtualbox" do |v|
+        v.memory = {{ mem_size }}
+        v.cpus = {{ cpu_count }}
+    end
+
+    config.vm.boot_timeout = 600
+
+{% if vms is defined and image_name is defined %}
+    {{ generate_generic_vms(vms, image_name) }}
+{% endif %}
+
+end

--- a/edbdeploy/projects/virtualbox.py
+++ b/edbdeploy/projects/virtualbox.py
@@ -1,4 +1,5 @@
 import errno
+from ipaddress import ip_address
 import json
 import logging
 import os
@@ -14,6 +15,7 @@ from ..system import exec_shell
 from ..spec.virtualbox import VirtualBoxSpec
 from ..specifications import default, merge
 from ..virtualbox import VirtualBoxCli
+from ..render import build_vagrantfile
 
 
 class VirtualBoxProject(Project):
@@ -22,8 +24,9 @@ class VirtualBoxProject(Project):
 
     def hook_post_configure(self, env):
         # Hook function called by Project.configure()
-        # Build the vars files for Ansible
+
         self._build_ansible_vars_file(env)
+        self._build_vagrant_vars(env)
         # Copy VirtualBox Vagrant Config File into project dir.
         self._copy_virtualbox_configfiles(env)
 
@@ -128,12 +131,7 @@ class VirtualBoxProject(Project):
             # Load specifications
             cloud_spec = self._load_cloud_specs(env)
             defaults = default(cloud_spec)
-
-            if os.path.exists(os.path.join(self.project_path, "spec.json")):
-                user_spec = self._load_spec_file(os.path.join(self.project_path,
-                                                 "spec.json"))
-            else:
-                user_spec = default(VirtualBoxSpec.get(env.reference_architecture))
+            user_spec = self._load_user_spec(env)
 
             # Generate dbt-2 client and driver specs on the fly as it depends on
             # how many of each are desired.
@@ -231,7 +229,50 @@ class VirtualBoxProject(Project):
             'efm_version': env.efm_version,
             'use_hostname': env.use_hostname,
         }
+    
+    def _load_user_spec(self, env):
+        if os.path.exists(os.path.join(self.project_path, "spec.json")):
+            return self._load_spec_file(os.path.join(self.project_path,
+                                                "spec.json"))
+        else:
+            return default(VirtualBoxSpec.get(env.reference_architecture))
+
+    def _build_vagrant_vars(self, env):
+        """
+        Build Vagrantfile variables for jinja2 template
+        Templates available inside of edbdeploy/data/templates
+        """
+        os_image = env.cloud_spec['available_os'][env.operating_system]['image']
+        ip = ip_address(env.cloud_spec['ipv4'])
+        self.vagrant_vars = {
+            'mem_size': env.mem_size,
+            'cpu_count': env.cpu_count,
+            'image_name': os_image,
+            'image_url': '',
+            'vms': {}
+        }
         
+        # Assign ip address for virtual machines
+        self.vagrant_vars['vms']['pem'] = { 'ip': ip }
+        ip += 1
+        self.vagrant_vars['vms']['barman'] = { 'ip': ip }
+        ip += 1
+        self.vagrant_vars['vms']['primary'] = { 'ip': ip }
+        ip += 1
+        if self.ansible_vars['reference_architecture'] in ['EDB-RA-2', 'EDB-RA-3']:
+            for i in range(2, 4):
+                self.vagrant_vars['vms'][f"standby{i}"] = { 'ip': ip }
+                ip += 1
+        if self.ansible_vars['reference_architecture'] in ['EDB-RA-3']:
+            for i in  range(1, 4):
+                self.vagrant_vars['vms'][f"pgpool{i}"] = { 'ip': ip }
+                ip += 1
+        for i in range(env.cloud_spec['dbt2_client']['count']):
+            self.vagrant_vars['vms'][f'dbt2client{i}'] = { 'ip': ip }
+            ip += 1
+        for i in range(env.cloud_spec['dbt2_driver']['count']):
+            self.vagrant_vars['vms'][f'dbt2driver{i}'] = { 'ip': ip }
+            ip += 1
 
     def _build_virtualbox_ips(self, env):
         """
@@ -339,12 +380,13 @@ class VirtualBoxProject(Project):
 
         if env.reference_architecture in ['EDB-RA-2', 'EDB-RA-3']:
             for i in range(2, 4):
+                name = f"standby{i}"
                 try:
                     output = exec_shell(
                         [
                             self.bin("vagrant"),
                                 "ssh",
-                                "standby-%s" %i,
+                                name,
                                 "-c",
                                 "\"ip address",
                                 "show eth1", 
@@ -374,11 +416,12 @@ class VirtualBoxProject(Project):
         if env.reference_architecture == 'EDB-RA-3':
             for i in range(1, 4):
                 try:
+                    name = f"pgpool{i}"
                     output = exec_shell(
                         [
                             self.bin("vagrant"),
                                 "ssh",
-                                "pgpool-%s" %i,
+                                name,
                                 "-c",
                                 "\"ip address",
                                 "show eth1", 
@@ -406,13 +449,13 @@ class VirtualBoxProject(Project):
                         % env.cloud_spec['pooler_server_%s' % i]['name']
                     )
         for i in range(env.cloud_spec['dbt2_client']['count']):
-            name = 'dbt2_client_' + str(i)
+            name = f"dbt2client{i}"
             try:
                 output = exec_shell(
                     [
                         self.bin("vagrant"),
                             "ssh",
-                            'dbt2client-' + str(i),
+                            name,
                             "-c",
                             "\"ip address",
                             "show eth1",
@@ -440,13 +483,13 @@ class VirtualBoxProject(Project):
                     % name
                 )
         for i in range(env.cloud_spec['dbt2_driver']['count']):
-            name = 'dbt2_driver_' + str(i)
+            name = f"dbt2driver{i}"
             try:
                 output = exec_shell(
                     [
                         self.bin("vagrant"),
                             "ssh",
-                            'dbt2driver-' + str(i),
+                            name,
                             "-c",
                             "\"ip address",
                             "show eth1",
@@ -479,7 +522,6 @@ class VirtualBoxProject(Project):
         Create the user specification, if defined, Vagrantfile and Ansible
         playbook in project directory.
         """
-
         if getattr(env, 'spec_file', False):
             shutil.copy(env.spec_file.name,
                         os.path.join(self.project_path, "spec.json"))
@@ -488,8 +530,7 @@ class VirtualBoxProject(Project):
         fromplaybookfile = os.path.join(self.ansible_share_path, "%s.yml" % self.ansible_vars['reference_architecture'])
         playbookfile = os.path.join(self.project_path, "playbook.yml")
 
-        with AM("Copying Vagrant Config files into %s" % self.vagrantfile):
-            # Playbook File
+        with AM(f"Copying playbook file into {playbookfile}"):
             try:
                 shutil.copy(fromplaybookfile, playbookfile)
             except IOError as e:
@@ -498,85 +539,8 @@ class VirtualBoxProject(Project):
                 os.makedirs(os.path.dirname(self.vagrantfile))
                 shutil.copy(fromplaybookfile, playbookfile)
 
-        # Add logic to handle setting the image_name based on
-        # self.ansible_vars['operating_system'] when we support more than one
-        # operating_system.
-        image_name = 'mwedb/rockylinux8'
-        ip_prefix = '192.168.56.'
-        # TODO: Make the starting ip address configurable in the event there are
-        # multiple clusters to create.  We can't ask VirtualBox for unique IP
-        # addresses, but we can control the sequence.
-        current_ip = 100
-
-        vagrantfile = open(self.vagrantfile, 'w')
-        vagrantfile.write('Vagrant.configure("2") do |config|\n')
-        vagrantfile.write('    config.ssh.insert_key = false\n')
-        vagrantfile.write('    config.ssh.forward_agent = true\n')
-        vagrantfile.write('\n')
-        vagrantfile.write('    config.vm.provider "virtualbox" do |v|\n')
-        vagrantfile.write('        v.memory = ' + env.mem_size + '\n')
-        vagrantfile.write('        v.cpus = ' + env.cpu_count + '\n')
-        vagrantfile.write('    end\n')
-        vagrantfile.write('\n')
-        vagrantfile.write('    config.vm.boot_timeout = 600\n')
-        vagrantfile.write('\n')
-        vagrantfile.write('    config.vm.define "pem" do |pem|\n')
-        vagrantfile.write('        pem.vm.box = "' + image_name + '"\n')
-        vagrantfile.write('        pem.vm.network "private_network", ip: "' + ip_prefix + str(current_ip) + '"\n')
-        current_ip += 1
-        vagrantfile.write('        pem.vm.hostname = "pem"\n')
-        vagrantfile.write('    end\n')
-        vagrantfile.write('\n')
-        vagrantfile.write('    config.vm.define "barman" do |barman|\n')
-        vagrantfile.write('        barman.vm.box = "' + image_name + '"\n')
-        vagrantfile.write('        barman.vm.network "private_network", ip: "' + ip_prefix + str(current_ip) + '"\n')
-        current_ip += 1
-        vagrantfile.write('        barman.vm.hostname = "barman"\n')
-        vagrantfile.write('    end\n')
-        vagrantfile.write('\n')
-        vagrantfile.write('    config.vm.define "primary" do |primary|\n')
-        vagrantfile.write('        primary.vm.box = "' + image_name + '"\n')
-        vagrantfile.write('        primary.vm.network "private_network", ip: "' + ip_prefix + str(current_ip) + '"\n')
-        current_ip += 1
-        vagrantfile.write('        primary.vm.hostname = "primary"\n')
-        vagrantfile.write('    end\n')
-        if self.ansible_vars['reference_architecture'] in ['EDB-RA-2',
-                                                           'EDB-RA-3']:
-            for i in ['2', '3']:
-                vagrantfile.write('\n')
-                vagrantfile.write('    config.vm.define "standby-' + i + '" do |standby|\n')
-                vagrantfile.write('        standby.vm.box = "' + image_name + '"\n')
-                vagrantfile.write('        standby.vm.network "private_network", ip: "' + ip_prefix + str(current_ip) + '"\n')
-                current_ip += 1
-                vagrantfile.write('        standby.vm.hostname = "standby-' + i + '"\n')
-                vagrantfile.write('    end\n')
-        if self.ansible_vars['reference_architecture'] in ['EDB-RA-3']:
-            for i in ['1', '2', '3']:
-                vagrantfile.write('\n')
-                vagrantfile.write('    config.vm.define "pgpool-' + i + '" do |pgpool|\n')
-                vagrantfile.write('        pgpool.vm.box = "' + image_name + '"\n')
-                vagrantfile.write('        pgpool.vm.network "private_network", ip: "' + ip_prefix + str(current_ip) + '"\n')
-                current_ip += 1
-                vagrantfile.write('        pgpool.vm.hostname = "pgpool-' + i + '"\n')
-                vagrantfile.write('    end\n')
-        for i in range(env.cloud_spec['dbt2_client']['count']):
-            vagrantfile.write('\n')
-            vagrantfile.write('    config.vm.define "dbt2client-' + str(i) + '" do |dbt2client|\n')
-            vagrantfile.write('        dbt2client.vm.box = "' + image_name + '"\n')
-            vagrantfile.write('        dbt2client.vm.network "private_network", ip: "' + ip_prefix + str(current_ip) + '"\n')
-            current_ip += 1
-            vagrantfile.write('        dbt2client.vm.hostname = "dbt2client-' + str(i) + '"\n')
-            vagrantfile.write('    end\n')
-        for i in range(env.cloud_spec['dbt2_driver']['count']):
-            vagrantfile.write('\n')
-            vagrantfile.write('    config.vm.define "dbt2driver-' + str(i) + '" do |dbt2driver|\n')
-            vagrantfile.write('        dbt2driver.vm.box = "' + image_name + '"\n')
-            vagrantfile.write('        dbt2driver.vm.network "private_network", ip: "' + ip_prefix + str(current_ip) + '"\n')
-            current_ip += 1
-            vagrantfile.write('        dbt2driver.vm.hostname = "dbt2driver-' + str(i) + '"\n')
-            vagrantfile.write('    end\n')
-        vagrantfile.write('end\n')
-        vagrantfile.close()
+        with AM(f"Building Vagrantfile into {self.vagrantfile}"):
+            build_vagrantfile(self.vagrantfile, self.vagrant_vars)
 
     def remove(self):
         # Overload Project.remove()

--- a/edbdeploy/render.py
+++ b/edbdeploy/render.py
@@ -3,7 +3,7 @@ from jinja2 import Environment, FileSystemLoader
 import pathlib
 
 
-def render_template(template_name, servers_path, vars={}):
+def render_yaml_template(template_name, servers_path, vars={}):
     """
     Function in charge of generating file content based on:
     - a template file name, that template file must reside into data/templates.
@@ -29,12 +29,28 @@ def render_template(template_name, servers_path, vars={}):
 
 
 def build_inventory_yml(dest, servers_path, vars={}):
-    inventory = render_template('inventory.yml.j2', servers_path, vars)
+    inventory = render_yaml_template('inventory.yml.j2', servers_path, vars)
     with open(dest, 'w') as f:
         f.write(inventory)
 
 
 def build_config_yml(dest, servers_path, vars={}):
-    config = render_template('config.yml.j2', servers_path, vars)
+    config = render_yaml_template('config.yml.j2', servers_path, vars)
     with open(dest, 'w') as f:
         f.write(config)
+
+def render_vagrantfile_template(template_name, vars={}):
+    # Template directory is located in ./data/templates
+    current_dir = pathlib.Path(__file__).parent.resolve()
+    templates_dir = pathlib.PurePath.joinpath(current_dir, 'data/templates')
+    
+    file_loader = FileSystemLoader(str(templates_dir))
+    env = Environment(loader=file_loader, trim_blocks=True)
+    template = env.get_template(template_name)
+
+    return template.render(**vars)
+
+def build_vagrantfile(dest, vars={}, template_name='Vagrantfile.j2'):
+    vagrantfile = render_vagrantfile_template(template_name, vars)
+    with open(dest, 'w') as f:
+        f.write(vagrantfile)

--- a/edbdeploy/spec/virtualbox.py
+++ b/edbdeploy/spec/virtualbox.py
@@ -30,7 +30,7 @@ EDBRA1Spec = {
             ),
         },
     },
-    'ipv4': SpecValidator(type='ipv4', default='192.168.81.100'),
+    'ipv4': SpecValidator(type='ipv4', default='192.168.56.101'),
     'ssh_user': SpecValidator(type='string', default=None),
     'pg_data': SpecValidator(type='string', default=None),
     'pg_wal': SpecValidator(type='string', default=None),

--- a/edbdeploy/spec/virtualbox.py
+++ b/edbdeploy/spec/virtualbox.py
@@ -22,6 +22,15 @@ EDBRA1Spec = {
             default=0
         ),
     },
+    'available_os': {
+        'RockyLinux8': {
+            'image': SpecValidator(
+                type='string',
+                default='mwedb/rockylinux8',
+            ),
+        },
+    },
+    'ipv4': SpecValidator(type='ipv4', default='192.168.81.100'),
     'ssh_user': SpecValidator(type='string', default=None),
     'pg_data': SpecValidator(type='string', default=None),
     'pg_wal': SpecValidator(type='string', default=None),

--- a/edbdeploy/spec/virtualbox.py
+++ b/edbdeploy/spec/virtualbox.py
@@ -26,7 +26,7 @@ EDBRA1Spec = {
         'RockyLinux8': {
             'image': SpecValidator(
                 type='string',
-                default='mwedb/rockylinux8',
+                default='generic/rocky8',
             ),
         },
     },

--- a/edbdeploy/virtualbox.py
+++ b/edbdeploy/virtualbox.py
@@ -136,16 +136,6 @@ class VirtualBoxCli:
     def up(self):
         try:
             rc = exec_shell_live(
-                [
-                    self.bin("vagrant"),
-                    "init",
-                    "rockylinux/8",
-                ],
-                environ=self.environ,
-                cwd=self.vagrant_project_path
-            )
-
-            rc = exec_shell_live(
                 [   self.bin("vagrant"),
                     "up",
                 ],


### PR DESCRIPTION
VirtualBox changes:
* Jinja2 template generation for Vagrantfile
* vagrant init removed since vagrantfile is used
* Specs including dbt2 specs created and ips assigned during configure subcommand instead of provision subcommand
* Removed unused hook since Project.provision() is overridden
* New specs saved into project directory
* Spec file loaded during provision subcommand
* Docs updated

Revert PR: #349
Original PR: #345