### PR TITLE
Update max ansible version to 2.12.10

### DIFF
--- a/edbdeploy/ansible.py
+++ b/edbdeploy/ansible.py
@@ -16,7 +16,7 @@ class AnsibleCli:
         self.dir = dir
         # Ansible supported versions interval
         self.min_version = (2, 11, 0)
-        self.max_version = (2, 11, 1)
+        self.max_version = (2, 12, 10)
         # Path to look up for executable
         self.bin_path = None
         # Force Ansible binary path if bin_path exists and contains


### PR DESCRIPTION
Note: starting from ansible 2.12, minimal Python version is 3.8. It means, the setup command won't work if the Python version is lower than 3.8.