### PR TITLE
EFM 4.5 and EDB Ansible 3.16 support

### DIFF
--- a/edbdeploy/__init__.py
+++ b/edbdeploy/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "3.12.0"
 # Version number of the Ansible collection we want to use
-__edb_ansible_version__ = "3.11.0"
+__edb_ansible_version__ = "3.16.0"
 
 def to_num(version):
     """

--- a/edbdeploy/data/ansible/EDB-Always-On-Platinum.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On-Platinum.yml
@@ -39,7 +39,7 @@
       when: "'pemserver' in group_names"
     - role: manage_dbserver
       when: "'pemserver' in group_names"
-    - role: autotuning
+    - role: tuning
       when: "'pemserver' in group_names"
     - role: setup_pemserver
       when: "'pemserver' in group_names"

--- a/edbdeploy/data/ansible/EDB-Always-On-Silver.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On-Silver.yml
@@ -39,7 +39,7 @@
       when: "'pemserver' in group_names"
     - role: manage_dbserver
       when: "'pemserver' in group_names"
-    - role: autotuning
+    - role: tuning
       when: "'pemserver' in group_names"
     - role: setup_pemserver
       when: "'pemserver' in group_names"

--- a/edbdeploy/data/ansible/EDB-RA-1.yml
+++ b/edbdeploy/data/ansible/EDB-RA-1.yml
@@ -30,5 +30,5 @@
       when: "'setup_dbt2_client' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_dbt2
       when: "'setup_dbt2' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
-    - role: autotuning
-      when: "'autotuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: tuning
+      when: "'tuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"

--- a/edbdeploy/data/ansible/EDB-RA-2.yml
+++ b/edbdeploy/data/ansible/EDB-RA-2.yml
@@ -28,5 +28,5 @@
       when: "'setup_barman' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_pemagent
       when: "'setup_pemagent' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
-    - role: autotuning
-      when: "'autotuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: tuning
+      when: "'tuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"

--- a/edbdeploy/data/ansible/EDB-RA-3.yml
+++ b/edbdeploy/data/ansible/EDB-RA-3.yml
@@ -35,5 +35,5 @@
       when: "'setup_barman' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_pemagent
       when: "'setup_pemagent' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
-    - role: autotuning
-      when: "'autotuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: tuning
+      when: "'tuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"

--- a/edbdeploy/data/ansible/EDB-RA.yml
+++ b/edbdeploy/data/ansible/EDB-RA.yml
@@ -33,8 +33,8 @@
       when: "'setup_barmanserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_barman
       when: "'setup_barman' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
-    - role: autotuning
-      when: "'autotuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: tuning
+      when: "'tuning' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: pot_setup
       when: group_names | select('search','barmanserver') | list | count < 1
     - role: setup_pemagent

--- a/edbdeploy/options.py
+++ b/edbdeploy/options.py
@@ -97,26 +97,26 @@ class PgVersionOptionAzureDB:
 
 
 class EFMVersionOption:
-    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4']
-    default = '4.4'
+    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
+    default = '4.5'
     help = textwrap.dedent("""
-        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3 and 4.4.
+        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4 and 4.5.
         Default: %(default)s
     """)
 
 class EFMVersionOptionVMWare:
-    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4']
-    default = '4.4'
+    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
+    default = '4.5'
     help = textwrap.dedent("""
-        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3 and 4.4.
+        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4 and 4.5.
         Default: %(default)s
     """)
 
 class EFMVersionOptionVirtualBox:
-    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4']
-    default = '4.4'
+    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
+    default = '4.5'
     help = textwrap.dedent("""
-        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3 and 4.4.
+        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4 and 4.5.
         Default: %(default)s
     """)
 


### PR DESCRIPTION
Adding support from EFM 4.5 and making this version default for all EDB-RA architectures Also made edb-ansible 3.16 as a default version