### PR TITLE
Update for postgres-deployment

### DIFF
--- a/edbdeploy/__init__.py
+++ b/edbdeploy/__init__.py
@@ -1,6 +1,6 @@
-__version__ = "3.13.0"
+__version__ = "3.14.0"
 # Version number of the Ansible collection we want to use
-__edb_ansible_version__ = "3.16.0"
+__edb_ansible_version__ = "3.17.0"
 
 def to_num(version):
     """

--- a/edbdeploy/data/ansible/EDB-Always-On-Platinum.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On-Platinum.yml
@@ -15,8 +15,8 @@
         disable_logging: false
         pg_unix_socket_directories:
             - "/tmp"
-        pem_agent_package: "edb-pem-agent-8.4.0"
-        pem_server_packages: "edb-pem-server-8.4.0"
+        pem_agent_package: "edb-pem-agent-9.0.0"
+        pem_server_packages: "edb-pem-server-9.0.0"
         reference_architecture: "EDB-Always-On-Platinum"
 
   post_tasks:

--- a/edbdeploy/data/ansible/EDB-Always-On-Silver.yml
+++ b/edbdeploy/data/ansible/EDB-Always-On-Silver.yml
@@ -15,8 +15,8 @@
         disable_logging: false
         pg_unix_socket_directories:
             - "/tmp"
-        pem_agent_package: "edb-pem-agent-8.4.0"
-        pem_server_packages: "edb-pem-server-8.4.0"
+        pem_agent_package: "edb-pem-agent-9.0.0"
+        pem_server_packages: "edb-pem-server-9.0.0"
         reference_architecture: "EDB-Always-On-Silver"
 
   post_tasks:

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/os_configure_user.yml
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/tasks/os_configure_user.yml
@@ -51,7 +51,7 @@
     group: root
     mode: 0644
   become: yes
-  when: group_names is subset(['pgbouncer'])
+  when: group_names is subset(['pgbouncer', 'primary'])
 
 - name: Add harp-proxy-pgbouncer-monitor.sh file
   template:
@@ -61,7 +61,7 @@
     group: root
     mode: 0755
   become: yes
-  when: group_names is subset(['pgbouncer'])
+  when: group_names is subset(['pgbouncer', 'primary'])
 
 - name: Add barman-backup-monitor.py file
   template:

--- a/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/harp-proxy-pgbouncer-monitor.sh.templates
+++ b/edbdeploy/data/ansible/roles/bdr_pot_setup/templates/harp-proxy-pgbouncer-monitor.sh.templates
@@ -44,23 +44,74 @@ PGBIN="{{ pg_bin_path }}"
 PGPORT="{{ pg_port }}"
 PGOWNER="{{ pg_owner }}"
 STATUS_MSG="status\tmessage"
-HARPPROXY_SERVICE="harp-proxy"
+HARP_PROXY_SERVICE="harp-proxy"
+HARP_PROXY_PORT="{{ harp_proxy_port }}"
+HARP_MANAGER_SERVICE="harp-manager"
+ETCD_SERVICE="etcd"
 PGBOUNCER_PORT="{{ pgbouncer_port }}"
 PYTHON3="/usr/bin/python3"
 PGDATABASE="{{ pg_database }}"
-export PGBIN HARPPROXY_SERVICE PGPORT STATUS_MSG
+export PGBIN HARP_PROXY_SERVICE PGPORT STATUS_MSG
+export ETCD_SERVICE HARP_MANAGER_SERVICE
+
+################################################################################
+# harp-proxy is running or not
+################################################################################
 
 function is_harp-proxy_running()
 {
-    /bin/systemctl status ${HARPPROXY_SERVICE} >/dev/null 2>&1
+    /bin/systemctl status ${HARP_PROXY_SERVICE} >/dev/null 2>&1
     if [[ $? -ne 0 ]]
     then
         echo -e "${STATUS_MSG}"
         echo -e "NOT OK\tharp-proxy is not running"
         exit 0
     fi
+    ${PGBIN}/pg_isready -h 127.0.0.1 -p ${HARP_PROXY_PORT} -d ${PGDATABASE} -q
+    if [[ $? -ne 0 ]]
+    then
+        echo -e "${STATUS_MSG}"
+        echo -e "NOT OK\tharp-proxy is not redirecting connections"
+        exit 0
+    fi
     echo -e "${STATUS_MSG}"
     echo -e "OK\tharp-proxy is running"
+    exit 0
+}
+
+################################################################################
+# harp-manager is running or not
+################################################################################
+
+function is_harp-manager_running()
+{
+    /bin/systemctl status ${HARP_MANAGER_SERVICE} >/dev/null 2>&1
+    if [[ $? -ne 0 ]]
+    then
+        echo -e "${STATUS_MSG}"
+        echo -e "NOT OK\tharp-manager is not running"
+        exit 0
+    fi
+    echo -e "${STATUS_MSG}"
+    echo -e "OK\tharp-manager is running"
+    exit 0
+}
+
+################################################################################
+# etcd is running or not
+################################################################################
+
+function is_etcd_running()
+{
+    /bin/systemctl status ${ETCD_SERVICE} >/dev/null 2>&1
+    if [[ $? -ne 0 ]]
+    then
+        echo -e "${STATUS_MSG}"
+        echo -e "NOT OK\tetcd is not running"
+        exit 0
+    fi
+    echo -e "${STATUS_MSG}"
+    echo -e "OK\tetcd is running"
     exit 0
 }
 
@@ -114,6 +165,12 @@ case "$1" in
     --harp-proxy-health)
         is_harp-proxy_running
         ;;
+    --harp-manager-health)
+        is_harp-manager_running
+        ;;
+    --etcd-health)
+        is_etcd_running
+        ;;
     --pgbouncer-health)
         is_pgbouncer_running
         ;;
@@ -123,6 +180,8 @@ case "$1" in
     *)
         echo "ERROR: Unknown Option. Options are listed below"
 	echo "   --harp-proxy-health"
+	echo "   --harp-manager-health"
+	echo "   --etcd-health"
 	echo "   --pgbouncer-health"
 	echo "   --pgbouncer-stats"
         ;;

--- a/edbdeploy/options.py
+++ b/edbdeploy/options.py
@@ -97,26 +97,26 @@ class PgVersionOptionAzureDB:
 
 
 class EFMVersionOption:
-    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
-    default = '4.5'
+    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6']
+    default = '4.6'
     help = textwrap.dedent("""
-        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4 and 4.5.
+        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5 and 4.6.
         Default: %(default)s
     """)
 
 class EFMVersionOptionVMWare:
-    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
-    default = '4.5'
+    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6']
+    default = '4.6'
     help = textwrap.dedent("""
-        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4 and 4.5.
+        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5 and 4.6.
         Default: %(default)s
     """)
 
 class EFMVersionOptionVirtualBox:
-    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
-    default = '4.5'
+    choices = ['3.10', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6']
+    default = '4.6'
     help = textwrap.dedent("""
-        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4 and 4.5.
+        EDB Failover Manager version. Allowed values are: 3.10, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5 and 4.6.
         Default: %(default)s
     """)
 

--- a/edbdeploy/tpaexec.py
+++ b/edbdeploy/tpaexec.py
@@ -26,8 +26,8 @@ class TPAexecCli:
         self.environ['ANSIBLE_PIPELINING'] = 'true'
         self.environ['ANSIBLE_SSH_PIPELINING'] = 'true'
         # Terraform supported version interval
-        self.min_version = (22, 14)
-        self.max_version = (22, 14)
+        self.min_version = (22, 15)
+        self.max_version = (23, 11)
         # Path to look up for executable
         self.bin_path = None
         # Force tpaexec binary path if bin_path exists and contains


### PR DESCRIPTION
This PR pushes the following changes
1. Bump the postgres-deployment version
2. Make postgres-deployment to use latest version of edb-ansible
3. Use the latest version of PEM 9.0.0
4. BDR POt has monitoring of HARP/ETCD
5. Added support for latest version of TPAExec for BDR PoT