### PR TITLE
terraform updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Third party pre-requisites:
    Depending on the cloud provider, install the **latest version** for: AWS
    CLI, Azure CLI or Google Cloud SDK on the system.
 
-2. **Terraform** >= 0.15.1
+2. **Terraform** >= 1.3.6
 3. **Ansible** >= 2.10.8
 4. **AWS CLI** >= 2.0.45
 5. **Azure CLI** >= 2.23.0

--- a/edbdeploy/terraform.py
+++ b/edbdeploy/terraform.py
@@ -21,8 +21,8 @@ class TerraformCli:
         self.environ = os.environ.copy()
         self.environ['TF_PLUGIN_CACHE_DIR'] = self.plugin_cache_dir
         # Terraform supported version interval
-        self.min_version = (1, 3, 0)
-        self.max_version = (1, 3, 7)
+        self.min_version = (1, 3, 6)
+        self.max_version = (1, 3, 9)
         # Path to look up for executable
         self.bin_path = None
         # Force Terraform binary path if bin_path exists and contains

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ Advanced Server, and EDB Tools in the Cloud.
         "PyYAML>=5.1",
         "psutil",
         "jinja2",
-        "edb-terraform@https://github.com/EnterpriseDB/edb-terraform/archive/refs/heads/v1_2.zip",
+        "edb-terraform@https://github.com/EnterpriseDB/edb-terraform/archive/refs/tags/v1.3.0.zip",
     ],
     extras_require={},
     data_files=[],


### PR DESCRIPTION
* README updated
* Terraform restricted between `1.3.6` and `1.3.9`
  * `edb-terraform` modules depend on various bug fixes and features not available earlier
* EDB-Terraform setup with git tag release `1.3.0`